### PR TITLE
Java8mig372 on clone integration 2

### DIFF
--- a/apg-patch-service-cmdclient/build.gradle
+++ b/apg-patch-service-cmdclient/build.gradle
@@ -19,7 +19,7 @@ targetCompatibility = 1.8
 
 def finalName = 'apg-patch-cli'
 
-mainClassName = 'pli'
+mainClassName = 'pliStarter'
 def repoTarget= version.endsWith("SNAPSHOT") ? "snapshots" : "releases"
 jar {
 	baseName = "${finalName}"
@@ -33,7 +33,7 @@ def savedVersion = version
 shadowJar {
 	baseName = "${finalName}"
 	classifier = null
-   	version = null
+    version = null
 	exclude 'cmd.sh'
 	exclude '**/downloads/*'
 	exclude '**/uploads/*'
@@ -105,7 +105,7 @@ ospackage {
 	}
 
 	from('packaging/bin') {
-		include 'apscli.sh'
+		include '*.sh'
 		fileMode 0755
 		into 'bin'
 		//expand project.properties

--- a/apg-patch-service-cmdclient/packaging/bin/apscli.sh
+++ b/apg-patch-service-cmdclient/packaging/bin/apscli.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-java -Dapscli.env=production -jar /opt/apg-patch-cli/bin/apg-patch-cli.jar $@  
+java -Dapscli.env=production -jar /opt/apg-patch-cli/bin/apg-patch-cli.jar pli $@  

--- a/apg-patch-service-cmdclient/packaging/bin/apsdbcli.sh
+++ b/apg-patch-service-cmdclient/packaging/bin/apsdbcli.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+java -Dapscli.env=production -jar /opt/apg-patch-cli/bin/apg-patch-cli.jar pliDb $@  

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbCli.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbCli.groovy
@@ -37,7 +37,6 @@ class PatchDbCli {
 		}
 		try {
 			if(options.lpac) {
-				// TODO JHE: status should be passed as option ...
 				def status = options.lpacs[0]
 				def result = listPatchAfterClone(status)
 				cmdResults.results['lpac'] = result
@@ -63,17 +62,17 @@ class PatchDbCli {
 	}
 	
 	private def listPatchAfterClone(def status) {
-		//Query db to get list of patch to be installed on the target (target -> corresponds to a specific status, eg.: Informatiktest
+		//Query db to get list of patch to be installed fora given status
 		def jdbcConfigFile = new File(config.ops.groovy.file.path)
 		def defaultJdbcConfig = new ConfigSlurper().parse(jdbcConfigFile.toURI().toURL())
 		// If we don't force sql to be a String, ${status} will be replace with a "?" at the time we run the query.
 		def String sql = "SELECT id FROM cm_patch_install_sequence_f WHERE ${status}=1 AND (produktion = 0 OR chronology > trunc(SYSDATE))"
 		def dbConnection = Sql.newInstance(defaultJdbcConfig.db.url, defaultJdbcConfig.db.user, defaultJdbcConfig.db.passwd)
-		def patchNumber = []
+		def patchNumbers = []
 		dbConnection.eachRow(sql) { row ->
 			def rowId = row.ID
-			println "Row (Patch ID) ${rowId} added to the list of patch to be re-installed."
-			patchNumber.add(rowId)
+			println "Patch ${rowId} added to the list of patch to be re-installed."
+			patchNumbers.add(rowId)
 		}
 		
 		def listPatchFile = new File(config.postclone.list.patch.file.path)
@@ -82,10 +81,10 @@ class PatchDbCli {
 			listPatchFile.delete()
 		}
 		
-		def json = JsonOutput.toJson([patchlist:patchNumber])
+		def json = JsonOutput.toJson([patchlist:patchNumbers])
 		listPatchFile.write(new JsonBuilder(json).toPrettyString())
 		
-		return patchNumber
+		return patchNumbers
 	}
 	
 	private def parseConfig() {

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbCli.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbCli.groovy
@@ -1,0 +1,145 @@
+package com.apgsga.patch.service.client.db
+
+import org.codehaus.groovy.runtime.StackTraceUtils
+import org.springframework.core.io.ClassPathResource
+
+import com.apgsga.patch.service.client.PatchClientServerException
+
+import groovy.json.JsonBuilder
+import groovy.json.JsonOutput
+import groovy.sql.Sql
+
+class PatchDbCli {
+	
+	def config
+	
+	private PatchDbCli() {
+	}
+	
+	public static create() {
+		return new PatchDbCli()
+	}
+	
+	def process(def args) {
+		
+		println "apsDbCli running with ${profile} profile"
+		println args
+		
+		config = parseConfig()
+		
+		def cmdResults = new Expando();
+		cmdResults.returnCode = 1
+		cmdResults.results = [:]
+		def options = validateOpts(args)
+		if (!options) {
+			cmdResults.returnCode = 0
+			return cmdResults
+		}
+		try {
+			if(options.lpac) {
+				// TODO JHE: status should be passed as option ...
+				def status = options.lpacs[0]
+				def result = listPatchAfterClone(status)
+				cmdResults.results['lpac'] = result
+			}
+		} catch (PatchClientServerException e) {
+			System.err.println "Server Error ccurred on ${e.errorMessage.timestamp} : ${e.errorMessage.errorText} "
+			cmdResults.results['error'] = e.errorMessage
+			return cmdResults
+	
+		} catch (AssertionError e) {
+			System.err.println "Client Error ccurred ${e.message} "
+			cmdResults.results['error'] = e.message
+			return cmdResults
+	
+		} catch (Exception e) {
+			System.err.println " Unhandling Exception occurred "
+			System.err.println e.toString()
+			StackTraceUtils.printSanitizedStackTrace(e,new PrintWriter(System.err))
+			cmdResults.results['error'] = e
+			return cmdResults
+		}
+		
+	}
+	
+	private def listPatchAfterClone(def status) {
+		//Query db to get list of patch to be installed on the target (target -> corresponds to a specific status, eg.: Informatiktest
+		def jdbcConfigFile = new File(config.ops.groovy.file.path)
+		def defaultJdbcConfig = new ConfigSlurper().parse(jdbcConfigFile.toURI().toURL())
+		// If we don't force sql to be a String, ${status} will be replace with a "?" at the time we run the query.
+		def String sql = "SELECT id FROM cm_patch_install_sequence_f WHERE ${status}=1 AND (produktion = 0 OR chronology > trunc(SYSDATE))"
+		def dbConnection = Sql.newInstance(defaultJdbcConfig.db.url, defaultJdbcConfig.db.user, defaultJdbcConfig.db.passwd)
+		def patchNumber = []
+		dbConnection.eachRow(sql) { row ->
+			def rowId = row.ID
+			println "Row (Patch ID) ${rowId} added to the list of patch to be re-installed."
+			patchNumber.add(rowId)
+		}
+		
+		def listPatchFile = new File(config.postclone.list.patch.file.path)
+		
+		if(listPatchFile.exists()) {
+			listPatchFile.delete()
+		}
+		
+		def json = JsonOutput.toJson([patchlist:patchNumber])
+		listPatchFile.write(new JsonBuilder(json).toPrettyString())
+		
+		return patchNumber
+	}
+	
+	private def parseConfig() {
+		ClassPathResource res = new ClassPathResource('apscli.properties')
+		assert res.exists() : "apscli.properties doesn't exist or is not accessible!"
+		ConfigObject conf = new ConfigSlurper(profile).parse(res.URL);
+		return conf
+	}
+	
+	private getProfile() {
+		def apsCliEnv = System.getProperty("apscli.env")
+		// If apscli.env is not define, we assume we're testing
+		def prof =  apsCliEnv ?: "test"
+		return prof
+	}
+	
+	private def validateOpts(def args) {
+		// TODO JHE: Add oc, sr, rr and rtr description here.
+		def cli = new CliBuilder(usage: 'apsdbpli.sh -[h|lpac]')
+		cli.formatter.setDescPadding(0)
+		cli.formatter.setLeftPadding(0)
+		cli.formatter.setWidth(100)
+		cli.with {
+			h longOpt: 'help', 'Show usage information', required: false
+			lpac longOpt: 'listPatchAfterClone', args:1, argName: 'status', 'Get list of patches to be re-installed after a clone', required: false
+		}
+		
+		def options = cli.parse(args)
+		def error = false;
+		
+		if (!options | options.getOptions().size() == 0) {
+			println "No option have been provided, please see the usage."
+			cli.usage()
+			return null
+		}
+		
+		if(options.h) {
+			cli.usage()
+			return null
+		}
+		
+		if(options.lpac) {
+			if(options.lpacs.size() != 1) {
+				println("Target status is required when fetching list of patch to be re-installed.")
+				error = true
+			}
+		}
+		
+		if(error) {
+			cli.usage()
+			return null
+		}
+		
+		options
+		
+	}
+}

--- a/apg-patch-service-cmdclient/src/main/groovy/pli.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/pli.groovy
@@ -1,3 +1,0 @@
-import com.apgsga.patch.service.client.PatchCli
-
-System.exit(PatchCli.create().process(args).returnCode)

--- a/apg-patch-service-cmdclient/src/main/groovy/pliStarter.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/pliStarter.groovy
@@ -4,6 +4,8 @@ import com.apgsga.patch.service.client.PatchCli
 import com.apgsga.patch.service.client.db.PatchDbCli
 
 def client = args[0]
+
+// We remove with "pli" or "pliDb" from args as they have no meaning for PatchCli or PatchDbCli
 args = args - "pli"
 args = args - "pliDb"
  
@@ -17,3 +19,7 @@ if(client.equalsIgnoreCase("pliDb")) {
 	println "Starting pliDb client"
 	System.exit(PatchDbCli.create().process(args).returnCode)
 }
+
+println "pliStarter couldn't find an pli to be started with name ${client}."
+// Even if no error occured, we inform the caller (by returing an error status) that pli couldn't achieve any job. 
+System.exit(1)

--- a/apg-patch-service-cmdclient/src/main/groovy/pliStarter.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/pliStarter.groovy
@@ -1,0 +1,19 @@
+import org.apache.http.util.Args
+
+import com.apgsga.patch.service.client.PatchCli
+import com.apgsga.patch.service.client.db.PatchDbCli
+
+def client = args[0]
+args = args - "pli"
+args = args - "pliDb"
+ 
+
+if(client.equalsIgnoreCase("pli")) {
+	println "Starting pli client"
+	System.exit(PatchCli.create().process(args).returnCode)
+}
+
+if(client.equalsIgnoreCase("pliDb")) {
+	println "Starting pliDb client"
+	System.exit(PatchDbCli.create().process(args).returnCode)
+}

--- a/apg-patch-service-cmdclient/src/main/resources/apscli.properties
+++ b/apg-patch-service-cmdclient/src/main/resources/apscli.properties
@@ -10,6 +10,7 @@ environments {
         artifactory.url = 'https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga'
         artifactory.user = 'dev'
         artifactory.password = 'dev1234'
+        postclone.list.patch.file.path = 'src/test/resources/patchToBeReinstalled.json'
     }
     production {
         revision.file.path = '/var/opt/apg-patch-cli/Revisions.json'
@@ -21,6 +22,7 @@ environments {
         target.system.mapping.file.name = 'TargetSystemMappings.json'
         artifactory.url = 'https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga'
         artifactory.user = 'dev'
-        artifactory.password = 'dev1234'        
+        artifactory.password = 'dev1234'
+        postclone.list.patch.file.path = '/var/opt/apg-patch-cli/patchToBeReinstalled.json'        
     }
 }

--- a/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/DbCliIntegrationTest.groovy
+++ b/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/DbCliIntegrationTest.groovy
@@ -1,0 +1,47 @@
+package com.apgsga.patch.service.client
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.annotation.DirtiesContext.ClassMode
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+
+import com.apgsga.microservice.patch.server.MicroPatchServer
+import com.apgsga.patch.service.client.db.PatchDbCli
+
+import groovy.json.JsonSlurper
+import spock.lang.Specification
+
+// TODO JHE: to be verified, probably not all anntations are required here ...
+@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
+//@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT, classes = [MicroPatchServer.class ])
+@TestPropertySource(locations = "application-test.properties")
+@ActiveProfiles("test,mock,groovyactions")
+class DbCliIntegrationTest extends Specification {
+	
+	def "Patch DB Cli should print out help without errors"() {
+		def result = PatchDbCli.create().process(["-h"])
+		expect: "PatchDbCli returns null in case of help only (-h)"
+		result != null
+		result.returnCode == 0
+		result.results.size() == 0
+	}
+	
+	def "Patch DB Cli returns patch ids to be re-installed after a clone"() {
+		setup:
+			def patchDbCli = PatchDbCli.create()
+			def result
+			def outputFile = new File("src/test/resources/patchToBeReinstalled.json")
+		when:
+			result = patchDbCli.process(["-lpac", "Informatiktest"])
+		then:
+			result != null
+			outputFile.exists()
+			def patchList = new JsonSlurper().parseText(outputFile.text)
+			println "content of outputfile : ${patchList}"
+		cleanup:
+			outputFile.delete()
+	}
+
+}


### PR DESCRIPTION
apscli extended with a new "PatchDbCli" client. This is a first step only specific to JAVA8MIG372, but in the future we could/should write more specific client (for now we weill have PatchCli and PatchDbCli). We also have a new "sh" script in order to start the new client. This new client will however be called from within our code, so it doesn't have any influence on the part which has already been integrated into the clone mechanism.