### PR TITLE
tag only if vcs patch is not empty

### DIFF
--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/EntwicklungInstallationsbereitAction.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/EntwicklungInstallationsbereitAction.java
@@ -51,10 +51,14 @@ public class EntwicklungInstallationsbereitAction implements PatchAction {
 			public void run() {
 				LOGGER.info("Running EntwicklungInstallationsbereitAction PatchVcsCommands");
 				jschSession.preProcess();
-				jschSession.run(PatchVcsCommand.createTagPatchModulesCmd(patch.getPatchTag(), patch.getDbPatchBranch(),
-						patch.getDbObjectsAsVcsPath()));
-				jschSession.run(PatchVcsCommand.createTagPatchModulesCmd(patch.getPatchTag(),
-						patch.getMicroServiceBranch(), patch.getMavenArtifactsAsVcsPath()));
+				if(!patch.getDbObjectsAsVcsPath().isEmpty()) {
+					jschSession.run(PatchVcsCommand.createTagPatchModulesCmd(patch.getPatchTag(), patch.getDbPatchBranch(),
+							patch.getDbObjectsAsVcsPath()));
+				}
+				if(!patch.getMavenArtifactsAsVcsPath().isEmpty()) {
+					jschSession.run(PatchVcsCommand.createTagPatchModulesCmd(patch.getPatchTag(),
+							patch.getMicroServiceBranch(), patch.getMavenArtifactsAsVcsPath()));
+				}
 				jschSession.postProcess();
 				dependencyResolver.resolveDependencies(patch.getMavenArtifacts());
 				repo.savePatch(patch);


### PR DESCRIPTION
If a patch doesn't contain an Maven Artifact, it will be stuck into "Entwicklung Installationbereit" status. The following is seen in Patch Service log (Look for line starting with WARN):

2018-08-17 10:22:25.173  INFO 3098 --- [http-nio-127.0.0.1-9010-exec-9] c.a.m.p.s.i.GroovyScriptActionExecutor   : With binding:{configDir=file:///etc/opt/apg-patch-common, patchNumber=5741, configFileName=TargetSystemMappings.json, toState=EntwicklungInstallationsbereit, patchContainerBean=com.apgsga.microservice.patch.server.impl.SimplePatchContainerBean@5c5eefef}
2018-08-17 10:22:25.245  INFO 3098 --- [http-nio-127.0.0.1-9010-exec-9] s.i.EntwicklungInstallationsbereitAction : Running EntwicklungInstallationsbereitAction, with: 5741, EntwicklungInstallationsbereit, and parameters: {targetName=Entwicklung, target=CHEI212, stage=startPipelineAndTag}
2018-08-17 10:22:25.248  INFO 3098 --- [http-nio-127.0.0.1-9010-exec-9] c.a.m.p.s.i.p.AtomicFileWriteManager     : Atomic write of: {"className":"com.apgsga.microservice.patch.api.impl.PatchBean","patchNummer":"5741","serviceName":"It21Ui","microServiceBranch":"it21_release_9_0_6_admin_uimig","dbPatchBranch":"Patch_0900C1_5741","prodBranch":"HEAD","patchTag":"Patch_0900C1_5741_1","tagNr":1,"installationTarget":null,"baseVersionNumber":"9.0.6","revisionMnemoPart":"ADMIN-UIMIG","revisionNumber":null,"lastRevisionNumber":null,"dbObjects":[{"className":"com.apgsga.microservice.patch.api.impl.DbObjectBean","fileName":"aenv.test.vw.sql","filePath":"test.apgsga.jenkins-pipeline.it21-patch/src/main/sql/","moduleName":"test.apgsga.jenkins-pipeline.it21-patch"}],"mavenArtifacts":[],"dbObjectsAsVcsPath":["test.apgsga.jenkins-pipeline.it21-patch/src/main/sql//aenv.test.vw.sql"],"mavenArtifactsAsVcsPath":[]} to File: Patch5741.json
2018-08-17 10:22:25.248  INFO 3098 --- [http-nio-127.0.0.1-9010-exec-9] c.a.m.p.s.i.p.AtomicFileWriteManager     : Starting RM at '/var/opt/apg-patch-service-server/db' / '/var/opt/apg-patch-service-server/dbwork'
2018-08-17 10:22:25.248  INFO 3098 --- [http-nio-127.0.0.1-9010-exec-9] c.a.m.p.s.i.p.AtomicFileWriteManager     : Started RM
2018-08-17 10:22:25.248  INFO 3098 --- [http-nio-127.0.0.1-9010-exec-9] c.a.m.p.s.i.p.AtomicFileWriteManager     : Resource Manager started with target Dir: /var/opt/apg-patch-service-server/db, and work Dir: /var/opt/apg-patch-service-server/dbwork
2018-08-17 10:22:25.249  INFO 3098 --- [http-nio-127.0.0.1-9010-exec-9] c.a.m.p.s.i.p.AtomicFileWriteManager     : Started File write Transaction with: 16546fa7ae0-0
2018-08-17 10:22:25.251  INFO 3098 --- [http-nio-127.0.0.1-9010-exec-9] c.a.m.p.s.i.p.AtomicFileWriteManager     : Commited File write Transaction with: 16546fa7ae0-0
2018-08-17 10:22:25.252  INFO 3098 --- [pool-14-thread-1] s.i.EntwicklungInstallationsbereitAction : Running EntwicklungInstallationsbereitAction PatchVcsCommands
2018-08-17 10:22:25.252  INFO 3098 --- [http-nio-127.0.0.1-9010-exec-9] c.a.m.p.s.i.GroovyScriptActionExecutor   : Result: Ok: Created Patch Tag and started Prod Patch Pipeline for: 5741
2018-08-17 10:22:25.252  INFO 3098 --- [http-nio-127.0.0.1-9010-exec-9] c.a.m.p.server.PatchOpServiceController  : Got executeStateChangeAction Request for Patch: 5741, toState: EntwicklungInstallationsbereit Done.
2018-08-17 10:22:25.360  INFO 3098 --- [pool-14-thread-1] c.a.m.p.server.impl.vcs.PatchVcsCommand  : ProcessBuilder Parameters: [/usr/bin/cvs, -d, /var/local/cvs/root, rtag, -r, Patch_0900C1_5741, Patch_0900C1_5741_1, test.apgsga.jenkins-pipeline.it21-patch/src/main/sql//aenv.test.vw.sql]
2018-08-17 10:22:25.360  INFO 3098 --- [pool-14-thread-1] c.a.m.p.s.impl.vcs.JschCommandRunner     : Executing: /usr/bin/cvs -d /var/local/cvs/root rtag -r Patch_0900C1_5741 Patch_0900C1_5741_1 test.apgsga.jenkins-pipeline.it21-patch/src/main/sql//aenv.test.vw.sql
2018-08-17 10:22:25.464  INFO 3098 --- [pool-14-thread-1] c.a.m.p.s.impl.vcs.JschCommandRunner     : Ssh Channel Exitstatus: 0
2018-08-17 10:22:25.464  INFO 3098 --- [pool-14-thread-1] c.a.m.p.s.impl.vcs.JschCommandRunner     : Done: /usr/bin/cvs -d /var/local/cvs/root rtag -r Patch_0900C1_5741 Patch_0900C1_5741_1 test.apgsga.jenkins-pipeline.it21-patch/src/main/sql//aenv.test.vw.sql
2018-08-17 10:22:25.464  INFO 3098 --- [pool-14-thread-1] c.a.m.p.server.impl.vcs.PatchVcsCommand  : ProcessBuilder Parameters: [/usr/bin/cvs, -d, /var/local/cvs/root, rtag, -r, it21_release_9_0_6_admin_uimig, Patch_0900C1_5741_1]
2018-08-17 10:22:25.464  INFO 3098 --- [pool-14-thread-1] c.a.m.p.s.impl.vcs.JschCommandRunner     : Executing: /usr/bin/cvs -d /var/local/cvs/root rtag -r it21_release_9_0_6_admin_uimig Patch_0900C1_5741_1
2018-08-17 10:22:25.486  INFO 3098 --- [pool-14-thread-1] c.a.m.p.s.impl.vcs.JschCommandRunner     : Ssh Channel Exitstatus: 1
2018-08-17 10:22:25.486  **WARN 3098 --- [pool-14-thread-1] c.a.m.p.s.impl.vcs.JschCommandRunner     : Command : /usr/bin/cvs -d /var/local/cvs/root rtag -r it21_release_9_0_6_admin_uimig Patch_0900C1_5741_1 returning with exit code: 1**
2018-08-17 10:22:25.486  INFO 3098 --- [pool-14-thread-1] c.a.m.p.s.impl.vcs.JschCommandRunner     : Done: /usr/bin/cvs -d /var/local/cvs/root rtag -r it21_release_9_0_6_admin_uimig Patch_0900C1_5741_1
2018-08-17 10:22:25.486  INFO 3098 --- [pool-14-thread-1] .a.a.q.i.ArtifactsDependencyResolverImpl : Resolving Dependencies

I suggest we tag code only when objects have to be tagged. However i'm not 100 sure if it might have any influence further in our process (I don't believe so) ... reason for this short pull request.
