### PR TITLE
Calling OPS Script to delete Jadas Image

### DIFF
--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchArtifactoryClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchArtifactoryClient.groovy
@@ -66,9 +66,11 @@ class PatchArtifactoryClient {
 			}
 			
 			// Cleaning Docker Image as well
-			def jadasCleanupCmd = "/opt/apgops/cleanup_jadas_images.sh ${from} ${lastRevision}"
-			['bash', '-c', jadasCleanupCmd].execute().in.text
-			println "Jadas Images have been deleted for ${target}"
+			if(!dryRun) {
+				def jadasCleanupCmd = "/opt/apgops/cleanup_jadas_images.sh ${from} ${lastRevision}"
+				['bash', '-c', jadasCleanupCmd].execute().in.text
+				println "Jadas Images have been deleted for ${target}"
+			}
 			
 		}
 		else {

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchArtifactoryClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchArtifactoryClient.groovy
@@ -64,6 +64,12 @@ class PatchArtifactoryClient {
 				removeArtifacts("*${FIRST_PART_FOR_ARTIFACT_SEARCH}${from}*", dryRun)
 				from++
 			}
+			
+			// Cleaning Docker Image as well
+			def jadasCleanupCmd = "/opt/apgops/cleanup_jadas_images.sh ${from} ${lastRevision}"
+			['bash', '-c', jadasCleanupCmd].execute().in.text
+			println "Jadas Images have been deleted for ${target}"
+			
 		}
 		else {
 			println("No release to clean for ${target}. We probably never have any patch installed directly on ${target}, or no patch has been newly installed since last clone.")


### PR DESCRIPTION
LIP provided a new script to be called in order to delete Jadas Images which won't be used anymore. 
As discussed, we will call this script at the time we clean our Releases on Artifactory.
What do you think? Do you agree with the place where the script would be called?

(we basically need a "from" and "to" parameters...)