### PR TITLE
Patch Libraries changes to PropertyFileBasedVersionManager

### DIFF
--- a/apg-patch-artifact-querymanager/src/main/java/com/apgsga/artifact/query/impl/ArtifactsDependencyResolverImpl.java
+++ b/apg-patch-artifact-querymanager/src/main/java/com/apgsga/artifact/query/impl/ArtifactsDependencyResolverImpl.java
@@ -71,7 +71,8 @@ public class ArtifactsDependencyResolverImpl implements ArtifactDependencyResolv
 		if (artifacts.isEmpty()) {
 			return resolvedDependencies;
 		}
-        ExecutorService executorService = Executors.newFixedThreadPool(artifacts.size());
+		// TODO (che,13.9) : Make Pool size configurable
+        ExecutorService executorService = Executors.newFixedThreadPool(20);
         List<Callable<MavenArtWithDependencies>> callables = Lists.newArrayList();
         for (MavenArtifact art : artifacts) {
         		Callable<MavenArtWithDependencies> callable = () ->  {

--- a/apg-patch-artifact-querymanager/src/main/java/com/apgsga/artifact/query/impl/PropertyFileBasedVersionManager.java
+++ b/apg-patch-artifact-querymanager/src/main/java/com/apgsga/artifact/query/impl/PropertyFileBasedVersionManager.java
@@ -2,25 +2,36 @@ package com.apgsga.artifact.query.impl;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
+import org.assertj.core.util.Lists;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 
 import com.apgsga.artifact.query.ArtifactManager;
 import com.apgsga.artifact.query.ArtifactVersionManager;
+import com.apgsga.microservice.patch.api.MavenArtifact;
 import com.apgsga.microservice.patch.exceptions.ExceptionFactory;
 
 public class PropertyFileBasedVersionManager implements ArtifactVersionManager {
 
 	private ArtifactManager artifactManager;
 	private Properties versionsProperties;
+	private List<Map<String,String>> mavenArtefactsToOverride = Lists.emptyList();
 
 	public PropertyFileBasedVersionManager(URI mavenLocalPath, String bomGroupId, String bomArtifactId) {
 		super();
 		this.artifactManager = ArtifactManager.create(bomGroupId, bomArtifactId, mavenLocalPath.getPath());
 
+	}
+	
+	public PropertyFileBasedVersionManager(URI mavenLocalPath, String bomGroupId, String bomArtifactId, List<Map<String,String>>  mavenArtefactsToOverride) {
+		super();
+		this.artifactManager = ArtifactManager.create(bomGroupId, bomArtifactId, mavenLocalPath.getPath());
+		this.mavenArtefactsToOverride = mavenArtefactsToOverride;
 	}
 
 	@Override
@@ -32,9 +43,24 @@ public class PropertyFileBasedVersionManager implements ArtifactVersionManager {
 
 	private synchronized Properties getProperties(String bomVersion) {
 		if (versionsProperties == null) {
+			Properties overrideVersionProperties = convertToProperties(mavenArtefactsToOverride); 
 			versionsProperties = intialLoad(artifactManager,bomVersion);
+			for (Object key : overrideVersionProperties.keySet()) {
+				versionsProperties.put(key, overrideVersionProperties.get(key)); 
+			}
 		}
 		return versionsProperties;
+	}
+
+	@SuppressWarnings("unchecked")
+	private Properties convertToProperties(List<Map<String,String>> mavenArtefactsToOverride) {
+		final Properties properties = new Properties();
+		for (Map<String,String> art : mavenArtefactsToOverride) {
+			if (!art.get("version").endsWith("SNAPSHOT")) {
+				properties.put(art.get("groupId") + ":" + art.get("artifactId"), art.get("version")); 
+			}
+		}
+		return properties; 
 	}
 
 	private static Properties intialLoad(ArtifactManager artifactManager,String bomVersion) {

--- a/apg-patch-artifact-querymanager/src/test/groovy/com/apgsga/artifact/query/PropertyFileBasedVersionManagerTests.groovy
+++ b/apg-patch-artifact-querymanager/src/test/groovy/com/apgsga/artifact/query/PropertyFileBasedVersionManagerTests.groovy
@@ -16,7 +16,7 @@ import spock.lang.Specification;
 
 class PropertyFileBasedVersionManagerTests extends Specification {
 
-	def "Without additional MavenArtefact List"() {
+	def "Without additional Groovy Json Lists of Property Maps"() {
 		setup:
 		def rl = new FileSystemResourceLoader();
 		def resource = rl.getResource("target/maverepo");
@@ -26,8 +26,18 @@ class PropertyFileBasedVersionManagerTests extends Specification {
 		then:
 		assert result.equals("9.0.6.ADMIN-UIMIG-SNAPSHOT")
 	}
+	def "Without empty additional Groovy Json Lists of Property Maps"() {
+		setup:
+		def rl = new FileSystemResourceLoader();
+		def resource = rl.getResource("target/maverepo");
+		def artifactManager = new PropertyFileBasedVersionManager(resource.getURI(),"com.affichage.common.maven","dm-bom", [])
+		when:
+		def result = artifactManager.getVersionFor("com.affichage.it21.vk","zentraldispo-ui","9.0.6.ADMIN-UIMIG-SNAPSHOT")
+		then:
+		assert result.equals("9.0.6.ADMIN-UIMIG-SNAPSHOT")
+	}
 	
-	def "With additional MavenArtefact List Overriding Versions"() {
+	def "With additional additional Groovy Json Lists of Property Maps Overriding Version Numbers"() {
 		setup:
 		def rl = new FileSystemResourceLoader();
 		def mavenRepoResource = rl.getResource("target/maverepo");

--- a/apg-patch-artifact-querymanager/src/test/groovy/com/apgsga/artifact/query/PropertyFileBasedVersionManagerTests.groovy
+++ b/apg-patch-artifact-querymanager/src/test/groovy/com/apgsga/artifact/query/PropertyFileBasedVersionManagerTests.groovy
@@ -1,0 +1,46 @@
+package com.apgsga.artifact.query
+import java.lang.ClassLoader.ParallelLoaders
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import org.springframework.core.io.FileSystemResourceLoader
+import org.springframework.core.io.Resource
+import org.springframework.core.io.ResourceLoader
+import org.springframework.util.FileSystemUtils
+import com.apgsga.artifact.query.impl.PropertyFileBasedVersionManager
+import com.apgsga.microservice.patch.api.SearchCondition
+import com.google.common.collect.Count
+import groovy.json.JsonSlurper
+import spock.lang.Specification;
+
+class PropertyFileBasedVersionManagerTests extends Specification {
+
+	def "Without additional MavenArtefact List"() {
+		setup:
+		def rl = new FileSystemResourceLoader();
+		def resource = rl.getResource("target/maverepo");
+		def artifactManager = new PropertyFileBasedVersionManager(resource.getURI(),"com.affichage.common.maven","dm-bom")
+		when:
+		def result = artifactManager.getVersionFor("com.affichage.it21.vk","zentraldispo-ui","9.0.6.ADMIN-UIMIG-SNAPSHOT")
+		then:
+		assert result.equals("9.0.6.ADMIN-UIMIG-SNAPSHOT")
+	}
+	
+	def "With additional MavenArtefact List Overriding Versions"() {
+		setup:
+		def rl = new FileSystemResourceLoader();
+		def mavenRepoResource = rl.getResource("target/maverepo");
+		def patchFile = rl.getResource("classpath:Patch5797.json").getFile()
+		def patch = new JsonSlurper().parseText(patchFile.text)
+		def artifactManager = new PropertyFileBasedVersionManager(mavenRepoResource.getURI(),"com.affichage.common.maven","dm-bom", patch.mavenArtifacts)
+		when:
+		def resultZentralDispo = artifactManager.getVersionFor("com.affichage.it21.vk","zentraldispo-ui","9.0.6.ADMIN-UIMIG-SNAPSHOT")
+		def resultCommondao = artifactManager.getVersionFor("com.affichage.it21.adgis","adgis-common-dao","9.0.6.ADMIN-UIMIG-SNAPSHOT")
+		then:
+		assert resultZentralDispo.equals("9.0.6.ADMIN-UIMIG-SNAPSHOT")
+		assert resultCommondao.equals("9.9.9")
+	}
+	
+
+}

--- a/apg-patch-artifact-querymanager/src/test/resources/Patch5797.json
+++ b/apg-patch-artifact-querymanager/src/test/resources/Patch5797.json
@@ -1,0 +1,191 @@
+{
+	"className": "com.apgsga.microservice.patch.api.impl.PatchBean",
+	"patchNummer": "5797",
+	"serviceName": "It21Ui",
+	"microServiceBranch": "it21_release_9_0_6_admin_uimig",
+	"dbPatchBranch": "Patch_0900C1_5797",
+	"prodBranch": "HEAD",
+	"patchTag": "",
+	"tagNr": 0,
+	"installationTarget": null,
+	"baseVersionNumber": "9.0.6",
+	"revisionMnemoPart": "ADMIN-UIMIG",
+	"revisionNumber": null,
+	"lastRevisionNumber": null,
+	"dbObjects": [
+	],
+	"mavenArtifacts": [
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "zentraldispo-ui",
+			"groupId": "com.affichage.it21.vk",
+			"name": "com.affichage.it21.vk.zentraldispo.ui",
+			"version": "9.0.6.ADMIN-UIMIG-SNAPSHOT",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "zentraldispo-dao",
+			"groupId": "com.affichage.it21.vk",
+			"name": "com.affichage.it21.vk.zentraldispo.dao",
+			"version": "9.0.6.ADMIN-UIMIG-SNAPSHOT",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "gp-dao",
+			"groupId": "com.affichage.it21.gp",
+			"name": "com.affichage.it21.gp.dao",
+			"version": "9.0.6.ADMIN-UIMIG-SNAPSHOT",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "gp-ui",
+			"groupId": "com.affichage.it21.gp",
+			"name": "com.affichage.it21.gp.ui",
+			"version": "9.0.6.ADMIN-UIMIG-SNAPSHOT",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "adgis-api-ui",
+			"groupId": "com.affichage.it21.adgis",
+			"name": null,
+			"version": "9.9.9",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "adgis-common-dao",
+			"groupId": "com.affichage.it21.adgis",
+			"name": null,
+			"version": "9.9.9",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "adgis-api-dao",
+			"groupId": "com.affichage.it21.adgis",
+			"name": null,
+			"version": "9.9.9",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "adgis-component",
+			"groupId": "com.affichage.adgis.component",
+			"name": null,
+			"version": "9.9.9",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "common-messaging",
+			"groupId": "com.affichage.common",
+			"name": null,
+			"version": "9.9.9",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "geo-lib",
+			"groupId": "com.affichage.geo.lib",
+			"name": null,
+			"version": "9.9.9",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "jgoodies-utils",
+			"groupId": "com.affichage.ui.utils",
+			"name": null,
+			"version": "9.9.9",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "common-rep-dao",
+			"groupId": "com.apgsga.common.rep",
+			"name": null,
+			"version": "9.9.9",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "common-rep-ui",
+			"groupId": "com.apgsga.common.rep",
+			"name": null,
+			"version": "9.9.9",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "forms2java",
+			"groupId": "com.apgsga",
+			"name": null,
+			"version": "9.9.9",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "apg-jasperreport",
+			"groupId": "com.apgsga",
+			"name": null,
+			"version": "9.9.9",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "ibus-domainwerte",
+			"groupId": "com.apgsga.it21.ibus",
+			"name": null,
+			"version": "9.9.9",
+			"dependencyLevel": 0
+		}
+	],
+	"installOnEmptyModules": true,
+	"dbObjectsAsVcsPath": [
+	],
+	"mavenArtifactsToBuild": [
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "zentraldispo-ui",
+			"groupId": "com.affichage.it21.vk",
+			"name": "com.affichage.it21.vk.zentraldispo.ui",
+			"version": "9.0.6.ADMIN-UIMIG-SNAPSHOT",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "zentraldispo-dao",
+			"groupId": "com.affichage.it21.vk",
+			"name": "com.affichage.it21.vk.zentraldispo.dao",
+			"version": "9.0.6.ADMIN-UIMIG-SNAPSHOT",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "gp-dao",
+			"groupId": "com.affichage.it21.gp",
+			"name": "com.affichage.it21.gp.dao",
+			"version": "9.0.6.ADMIN-UIMIG-SNAPSHOT",
+			"dependencyLevel": 0
+		},
+		{
+			"className": "com.apgsga.microservice.patch.api.impl.MavenArtifactBean",
+			"artifactId": "gp-ui",
+			"groupId": "com.affichage.it21.gp",
+			"name": "com.affichage.it21.gp.ui",
+			"version": "9.0.6.ADMIN-UIMIG-SNAPSHOT",
+			"dependencyLevel": 0
+		}
+	],
+	"mavenArtifactsAsVcsPath": [
+		"com.affichage.it21.vk.zentraldispo.ui",
+		"com.affichage.it21.vk.zentraldispo.dao",
+		"com.affichage.it21.gp.dao",
+		"com.affichage.it21.gp.ui"
+	],
+	"installJadasAndGui": true
+}

--- a/apg-patch-service-cmdclient/build.gradle
+++ b/apg-patch-service-cmdclient/build.gradle
@@ -91,7 +91,7 @@ def homeDir = "/opt/${finalName}"
 ospackage {
 	packageName = "${finalName}"
 	version = "${savedVersion}"
-	release = 3
+	release = 1
 	os = LINUX
 	type = BINARY
 	arch = NOARCH

--- a/apg-patch-service-server/build.gradle
+++ b/apg-patch-service-server/build.gradle
@@ -69,7 +69,7 @@ def homeDir = "/opt/${project.name}"
 ospackage {
 	packageName = "${project.name}"
 	version = "${pkgVersion}"
-	release = 4
+	release = 1
 	os = LINUX
 	type = BINARY
 	arch = NOARCH

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ project.ext {
 allprojects  {
 	apply plugin: 'maven'
 	group = 'com.apgsga.patchframework'
-	version  = '1.1.23'
+	version  = '1.1.24'
 }
 
 subprojects {


### PR DESCRIPTION
Basically Mixin in List<Map<String,String> , which reflect the MavenArtefacts List of Patch*.json after deserializing them with JsonSlurper, The non  SNAPSHOT version from there , overrides those from the dm-bom.