### PR TITLE
Java8mig 410 move revision options to own cli

### DIFF
--- a/apg-patch-service-cmdclient/packaging/bin/apsrevcli.sh
+++ b/apg-patch-service-cmdclient/packaging/bin/apsrevcli.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+java -Dapscli.env=production -jar /opt/apg-patch-cli/bin/apg-patch-cli.jar pliRev $@  

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchArtifactoryClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchArtifactoryClient.groovy
@@ -2,6 +2,9 @@ package com.apgsga.patch.service.client
 
 import org.jfrog.artifactory.client.Artifactory
 import org.jfrog.artifactory.client.model.RepoPath
+
+import com.apgsga.patch.service.client.revision.PatchRevisionClient
+
 import org.jfrog.artifactory.client.ArtifactoryClientBuilder
 
 class PatchArtifactoryClient {

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbCli.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbCli.groovy
@@ -103,7 +103,6 @@ class PatchDbCli {
 	}
 	
 	private def validateOpts(def args) {
-		// TODO JHE: Add oc, sr, rr and rtr description here.
 		def cli = new CliBuilder(usage: 'apsdbpli.sh -[h|lpac]')
 		cli.formatter.setDescPadding(0)
 		cli.formatter.setLeftPadding(0)

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbClient.groovy
@@ -1,4 +1,4 @@
-package com.apgsga.patch.service.client
+package com.apgsga.patch.service.client.db
 import groovy.sql.Sql
 class PatchDbClient {
 	

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/revision/PatchRevisionCli.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/revision/PatchRevisionCli.groovy
@@ -1,0 +1,185 @@
+package com.apgsga.patch.service.client.revision
+
+import org.springframework.core.io.ClassPathResource
+
+import com.apgsga.patch.service.client.PatchArtifactoryClient
+import com.apgsga.patch.service.client.PatchClientServerException
+
+class PatchRevisionCli {
+	
+	def config
+	
+	private PatchRevisionCli() {
+	}
+	
+	public static create() {
+		return new PatchRevisionCli()
+	}	
+
+	def process(def args) {
+		
+		println "apsRevCli running with ${profile} profile"
+		println args
+		
+		config = parseConfig()
+		
+		def cmdResults = new Expando();
+		cmdResults.returnCode = 1
+		cmdResults.results = [:]
+		def options = validateOpts(args)
+		
+		if (!options) {
+			cmdResults.returnCode = 0
+			return cmdResults
+		}
+		
+		try {
+			if (options.sr) {
+				def result = saveRevisions(options)
+				cmdResults.results['sr'] = result
+			}
+			if (options.rr) {
+				def result = retrieveRevisions(options)
+				cmdResults.results['rr'] = result
+			}
+			if (options.pr) {
+				def result = retrieveLastProdRevision()
+				cmdResults.results['pr'] = result
+			}
+			if (options.resr) {
+				def result = resetRevision(options)
+				cmdResults.results['resr'] = result
+			}
+			// TODO JHE (26.06.2018): will be removed with JAVA8MIG-389
+			if (options.rtr) {
+				def result = removeAllTRevisions(options)
+				cmdResults.results['rtr'] = result
+			}
+			
+			cmdResults.returnCode = 0
+			return cmdResults
+		} catch (PatchClientServerException e) {
+			System.err.println "Server Error ccurred on ${e.errorMessage.timestamp} : ${e.errorMessage.errorText} "
+			cmdResults.results['error'] = e.errorMessage
+			return cmdResults
+
+		} catch (AssertionError e) {
+			System.err.println "Client Error ccurred ${e.message} "
+			cmdResults.results['error'] = e.message
+			return cmdResults
+
+		} catch (Exception e) {
+			System.err.println " Unhandling Exception occurred "
+			System.err.println e.toString()
+			StackTraceUtils.printSanitizedStackTrace(e,new PrintWriter(System.err))
+			cmdResults.results['error'] = e
+			return cmdResults
+		}
+		
+		
+	}
+	
+	def saveRevisions(def options) {
+		def patchRevisionClient = new PatchRevisionClient(config)
+		patchRevisionClient.saveRevisions(options.srs[0],options.srs[1],options.srs[2])
+	}
+	
+	def retrieveRevisions(def options) {
+		def patchRevisionClient = new PatchRevisionClient(config)
+		patchRevisionClient.retrieveRevisions(options.rrs[0],options.rrs[1])
+	}
+	
+	def retrieveLastProdRevision() {
+		def patchRevisionClient = new PatchRevisionClient(config)
+		patchRevisionClient.retrieveLastProdRevision()
+	}
+	
+	def resetRevision(def options) {
+		def patchRevisionClient = new PatchRevisionClient(config)
+		def target = options.resrs[0]
+		patchRevisionClient.resetLastRevision(target)
+	}
+	
+	// TODO JHE (26.06.2018): will be removed with JAVA8MIG-389
+	def removeAllTRevisions(def options) {
+		def patchArtifactoryClient = new PatchArtifactoryClient(config)
+		def dryRun = true
+		if(options.rtrs[0] == "0") {
+			dryRun = false
+		}
+		patchArtifactoryClient.deleteAllTRevisions(dryRun)
+	}
+	
+	private def validateOpts(def args) {
+		def cli = new CliBuilder(usage: 'apsrevpli.sh -[h|sr|rr|pr|resr]')
+		cli.formatter.setDescPadding(0)
+		cli.formatter.setLeftPadding(0)
+		cli.formatter.setWidth(100)
+		cli.with {
+			// TODO (CHE, 13.9) Factor out Revision Operations into Interface
+			h longOpt: 'help', 'Show usage information', required: false
+			sr longOpt: 'saveRevision', args:3, valueSeparator: ",", argName: 'targetInd,installationTarget,revision', 'Save revision file with new value for a given target', required: false
+			rr longOpt: 'retrieveRevision', args:2, valueSeparator: ",", argName: 'targetInd,installationTarget', 'Update revision with new value for given target', required: false
+			pr longOpt: 'prodRevision', args:0, 'Retrieve last revision for the production target', required: false
+			resr longOpt: 'resetRevision', args:1, argName: 'target', 'Reset revision number for a given target', required: false
+			// TODO JHE (26.06.2018): will be removed with JAVA8MIG-389
+			rtr longOpt: 'removeTRevisions', args:1, argName: 'dryRun', 'Remove all T Revision from Artifactory. dryRun=1 -> simulation only, dryRun=0 -> artifact will be deleted', required: false
+		}
+		
+		def options = cli.parse(args)
+		def error = false;
+
+		if (options == null) {
+			println "Wrong parameters"
+			cli.usage()
+			return null
+		}
+		
+		if (options.rr) {
+			if(options.rrs.size() != 2) {
+				println "2 parameters are required for the retrieveRevision command."
+				error = true
+			}
+		}
+		if (options.sr) {
+			if(options.srs.size() != 3) {
+				println "3 parameters are required for the saveRevision command."
+				error = true
+			}
+		}
+		if (options.resr) {
+			if(options.resrs.size() != 1) {
+				println "target parameter is required when reseting revision."
+				error = true
+			}
+		}
+		// TODO JHE (26.06.2018): will be removed with JAVA8MIG-389
+		if (options.rtr) {
+			if(options.rtrs.size() != 1) {
+				println "No parameter has been set, only a dryRun will be done. To delete all T artifact, please explicitely set dryRun to 0."
+				error = true
+			}
+		}
+
+		if (error) {
+			cli.usage()
+			return null
+		}
+		options
+	}
+	
+	
+	private def parseConfig() {
+		ClassPathResource res = new ClassPathResource('apscli.properties')
+		assert res.exists() : "apscli.properties doesn't exist or is not accessible!"
+		ConfigObject conf = new ConfigSlurper(profile).parse(res.URL);
+		return conf
+	}
+	
+	private getProfile() {
+		def apsCliEnv = System.getProperty("apscli.env")
+		// If apscli.env is not define, we assume we're testing
+		def prof =  apsCliEnv ?: "test"
+		return prof
+	}
+}

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/revision/PatchRevisionClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/revision/PatchRevisionClient.groovy
@@ -1,4 +1,4 @@
-package com.apgsga.patch.service.client
+package com.apgsga.patch.service.client.revision
 
 import groovy.json.JsonBuilder
 import groovy.json.JsonSlurper

--- a/apg-patch-service-cmdclient/src/main/groovy/pliStarter.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/pliStarter.groovy
@@ -2,12 +2,15 @@ import org.apache.http.util.Args
 
 import com.apgsga.patch.service.client.PatchCli
 import com.apgsga.patch.service.client.db.PatchDbCli
+import com.apgsga.patch.service.client.revision.PatchRevisionCli
 
 def client = args[0]
 
-// We remove with "pli" or "pliDb" from args as they have no meaning for PatchCli or PatchDbCli
+// We remove with "pli", "pliDb" pr "pliRev from args as they have no meaning for PatchCli or PatchDbCli
 args = args - "pli"
 args = args - "pliDb"
+args = args - "pliRev"
+
  
 
 if(client.equalsIgnoreCase("pli")) {
@@ -18,6 +21,11 @@ if(client.equalsIgnoreCase("pli")) {
 if(client.equalsIgnoreCase("pliDb")) {
 	println "Starting pliDb client"
 	System.exit(PatchDbCli.create().process(args).returnCode)
+}
+
+if(client.equalsIgnoreCase("pliRev")) {
+	println "Starting pliRev client"
+	System.exit(PatchRevisionCli.create().process(args).returnCode)
 }
 
 println "pliStarter couldn't find an pli to be started with name ${client}."

--- a/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/RevisionCliIntegrationTest.groovy
+++ b/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/RevisionCliIntegrationTest.groovy
@@ -1,0 +1,228 @@
+package com.apgsga.patch.service.client
+
+import groovy.json.JsonBuilder
+import groovy.json.JsonSlurper
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.annotation.DirtiesContext.ClassMode
+import org.springframework.test.context.TestPropertySource
+
+import com.apgsga.patch.service.client.revision.PatchRevisionCli
+
+import spock.lang.Specification
+
+@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
+@TestPropertySource(locations = "application-test.properties")
+class RevisionCliIntegrationTest extends Specification {
+	
+	def "Patch Cli validate retrieve and save revision"() {
+		setup:
+			def client = PatchRevisionCli.create()
+			PrintStream oldStream
+			def buffer
+			def revisionAsJson
+			def revisionsFromRRCall
+			def revisionsFromFile
+			def revisionsFile = new File("src/test/resources/Revisions.json")
+		when:
+			oldStream = System.out;
+			buffer = new ByteArrayOutputStream()
+			System.setOut(new PrintStream(buffer))
+			client.process(["-rr", "T,CHEI212"])
+			System.setOut(oldStream)
+			revisionAsJson = TestUtil.getRevisionLine(buffer.toString())
+			revisionsFromRRCall = new JsonSlurper().parseText(revisionAsJson)
+		then:
+			revisionsFromRRCall.fromRetrieveRevision.revision.toInteger() == 10000
+			revisionsFromRRCall.fromRetrieveRevision.lastRevision == "SNAPSHOT"
+			!revisionsFile.exists()
+		when:
+			client.process(["-sr", "T,CHEI212,${revisionsFromRRCall.fromRetrieveRevision.revision}"])
+			revisionsFromFile = new JsonSlurper().parseText(revisionsFile.text)
+		then:
+			revisionsFile.exists()
+			revisionsFromFile.lastRevisions["CHEI212"].toInteger() == 10000
+			revisionsFromFile.lastRevisions["CHEI211"] == null
+			revisionsFromFile.currentRevision["P"].toInteger() == 1
+			revisionsFromFile.currentRevision["T"].toInteger() == 20000
+		when:
+			oldStream = System.out;
+			buffer = new ByteArrayOutputStream()
+			System.setOut(new PrintStream(buffer))
+			client.process(["-rr", "T,CHEI211"])
+			System.setOut(oldStream)
+			revisionAsJson = TestUtil.getRevisionLine(buffer.toString())
+			revisionsFromRRCall = new JsonSlurper().parseText(revisionAsJson)
+			revisionsFromFile = new JsonSlurper().parseText(revisionsFile.text)
+		then:
+			revisionsFromRRCall.fromRetrieveRevision.revision.toInteger() == 20000
+			revisionsFromRRCall.fromRetrieveRevision.lastRevision == "SNAPSHOT"
+			revisionsFile.exists()
+			revisionsFromFile.lastRevisions["CHEI212"].toInteger() == 10000
+			revisionsFromFile.lastRevisions["CHEI211"] == null
+			revisionsFromFile.currentRevision["P"].toInteger() == 1
+			revisionsFromFile.currentRevision["T"].toInteger() == 20000
+		when:
+			client.process(["-sr", "T,CHEI211,${revisionsFromRRCall.fromRetrieveRevision.revision}"])
+			revisionsFromFile = new JsonSlurper().parseText(revisionsFile.text)
+		then:
+			revisionsFile.exists()
+			revisionsFromFile.lastRevisions["CHEI212"].toInteger() == 10000
+			revisionsFromFile.lastRevisions["CHEI211"].toInteger() == 20000
+			revisionsFromFile.currentRevision["P"].toInteger() == 1
+			revisionsFromFile.currentRevision["T"].toInteger() == 30000
+		when:
+			oldStream = System.out;
+			buffer = new ByteArrayOutputStream()
+			System.setOut(new PrintStream(buffer))
+			client.process(["-rr", "T,CHEI212"])
+			System.setOut(oldStream)
+			revisionAsJson = TestUtil.getRevisionLine(buffer.toString())
+			revisionsFromRRCall = new JsonSlurper().parseText(revisionAsJson)
+		then:
+			revisionsFromRRCall.fromRetrieveRevision.revision.toInteger() == 10001
+			revisionsFromRRCall.fromRetrieveRevision.lastRevision.toInteger() == 10000
+			revisionsFile.exists()
+		when:
+			client.process(["-sr", "T,CHEI212,${revisionsFromRRCall.fromRetrieveRevision.revision}"])
+			revisionsFromFile = new JsonSlurper().parseText(revisionsFile.text)
+		then:
+			revisionsFile.exists()
+			revisionsFromFile.lastRevisions["CHEI212"].toInteger() == 10001
+			revisionsFromFile.lastRevisions["CHEI211"].toInteger() == 20000
+			revisionsFromFile.currentRevision["P"].toInteger() == 1
+			revisionsFromFile.currentRevision["T"].toInteger() == 30000
+		when:
+			oldStream = System.out;
+			buffer = new ByteArrayOutputStream()
+			System.setOut(new PrintStream(buffer))
+			client.process(["-rr", "P,CHPI211"])
+			System.setOut(oldStream)
+			revisionAsJson = TestUtil.getRevisionLine(buffer.toString())
+			revisionsFromRRCall = new JsonSlurper().parseText(revisionAsJson)
+		then:
+			revisionsFromRRCall.fromRetrieveRevision.revision.toInteger() == 1
+			revisionsFromRRCall.fromRetrieveRevision.lastRevision == "SNAPSHOT"
+			revisionsFile.exists()
+		when:
+			client.process(["-sr", "P,CHPI211,${revisionsFromRRCall.fromRetrieveRevision.revision}"])
+			revisionsFromFile = new JsonSlurper().parseText(revisionsFile.text)
+		then:
+			revisionsFile.exists()
+			revisionsFromFile.lastRevisions["CHEI212"].toInteger() == 10001
+			revisionsFromFile.lastRevisions["CHEI211"].toInteger() == 20000
+			revisionsFromFile.lastRevisions["CHPI211"].toInteger() == 1
+			revisionsFromFile.currentRevision["P"].toInteger() == 2
+			revisionsFromFile.currentRevision["T"].toInteger() == 30000
+		when:
+			oldStream = System.out;
+			buffer = new ByteArrayOutputStream()
+			System.setOut(new PrintStream(buffer))
+			client.process(["-rr", "T,CHEI211"])
+			System.setOut(oldStream)
+			revisionAsJson = TestUtil.getRevisionLine(buffer.toString())
+			revisionsFromRRCall = new JsonSlurper().parseText(revisionAsJson)
+		then:
+			revisionsFromRRCall.fromRetrieveRevision.revision.toInteger() == 20001
+			revisionsFromRRCall.fromRetrieveRevision.lastRevision.toInteger() == 20000
+			revisionsFile.exists()
+		when:
+			client.process(["-sr", "T,CHEI211,${revisionsFromRRCall.fromRetrieveRevision.revision}"])
+			revisionsFromFile = new JsonSlurper().parseText(revisionsFile.text)
+		then:
+			revisionsFile.exists()
+			revisionsFromFile.lastRevisions["CHEI212"].toInteger() == 10001
+			revisionsFromFile.lastRevisions["CHEI211"].toInteger() == 20001
+			revisionsFromFile.lastRevisions["CHPI211"].toInteger() == 1
+			revisionsFromFile.currentRevision["P"].toInteger() == 2
+			revisionsFromFile.currentRevision["T"].toInteger() == 30000
+		when:
+			oldStream = System.out;
+			buffer = new ByteArrayOutputStream()
+			System.setOut(new PrintStream(buffer))
+			client.process(["-rr", "P,CHPI211"])
+			System.setOut(oldStream)
+			revisionAsJson = TestUtil.getRevisionLine(buffer.toString())
+			revisionsFromRRCall = new JsonSlurper().parseText(revisionAsJson)
+		then:
+			revisionsFromRRCall.fromRetrieveRevision.revision.toInteger() == 2
+			revisionsFromRRCall.fromRetrieveRevision.lastRevision.toInteger() == 1
+			revisionsFile.exists()
+		when:
+			client.process(["-sr", "P,CHPI211,${revisionsFromRRCall.fromRetrieveRevision.revision}"])
+			revisionsFromFile = new JsonSlurper().parseText(revisionsFile.text)
+		then:
+			revisionsFile.exists()
+			revisionsFromFile.lastRevisions["CHEI212"].toInteger() == 10001
+			revisionsFromFile.lastRevisions["CHEI211"].toInteger() == 20001
+			revisionsFromFile.lastRevisions["CHPI211"].toInteger() == 2
+			revisionsFromFile.currentRevision["P"].toInteger() == 3
+			revisionsFromFile.currentRevision["T"].toInteger() == 30000
+		when:
+			oldStream = System.out;
+			buffer = new ByteArrayOutputStream()
+			System.setOut(new PrintStream(buffer))
+			client.process(["-rr", "T,CHEI213"])
+			System.setOut(oldStream)
+			revisionAsJson = TestUtil.getRevisionLine(buffer.toString())
+			revisionsFromRRCall = new JsonSlurper().parseText(revisionAsJson)
+		then:
+			revisionsFromRRCall.fromRetrieveRevision.revision.toInteger() == 30000
+			revisionsFromRRCall.fromRetrieveRevision.lastRevision == "SNAPSHOT"
+			revisionsFile.exists()
+		when:
+			client.process(["-sr", "T,CHEI213,${revisionsFromRRCall.fromRetrieveRevision.revision}"])
+			revisionsFromFile = new JsonSlurper().parseText(revisionsFile.text)
+		then:
+			revisionsFile.exists()
+			revisionsFromFile.lastRevisions["CHEI212"].toInteger() == 10001
+			revisionsFromFile.lastRevisions["CHEI211"].toInteger() == 20001
+			revisionsFromFile.lastRevisions["CHEI213"].toInteger() == 30000
+			revisionsFromFile.lastRevisions["CHPI211"].toInteger() == 2
+			revisionsFromFile.currentRevision["P"].toInteger() == 3
+			revisionsFromFile.currentRevision["T"].toInteger() == 40000
+		cleanup:
+			revisionsFile.delete()
+	}
+	
+	def "Patch Cli validate retrieve last prod revision"() {
+		setup:
+			/*
+			 * For our tests, within src/test/resources/TargetSystemMappings.json, CHEI211 is configured as the
+			 * production target.
+			 *
+			 */
+			def client = PatchRevisionCli.create()
+			def revisionsFile = new File("src/test/resources/Revisions.json")
+			def currentRevision = [P:5,T:30000]
+			def lastRevision = [CHEI212:10036,CHEI211:4,CHEI213:20025]
+			def revisions = [lastRevisions:lastRevision, currentRevision:currentRevision]
+			revisionsFile.write(new JsonBuilder(revisions).toPrettyString())
+			def oldStream
+			def buffer
+			def revisionAsJson
+			def revisionsFromRRCall
+		when:
+			oldStream = System.out;
+			buffer = new ByteArrayOutputStream()
+			System.setOut(new PrintStream(buffer))
+			client.process(["-pr"])
+			System.setOut(oldStream)
+			revisionAsJson = TestUtil.getLastProdRevisionLine(buffer.toString())
+			revisionsFromRRCall = new JsonSlurper().parseText(revisionAsJson)
+		then:
+			revisionsFromRRCall.lastProdRevision.toInteger() == 4
+		cleanup:
+			revisionsFile.delete()
+	}
+	
+	// TODO JHE (26.06.2018): will be removed with JAVA8MIG-389
+	def "Patch Cli delete all T revision with dryRun"() {
+		setup:
+			def client = PatchCli.create()
+		when:
+			client.process(["-rtr", "1"]) // 1 -> dryRun
+		then:
+			// Simply nothing should happen.
+			notThrown(RuntimeException)
+	}
+}

--- a/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/TestUtil.groovy
+++ b/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/TestUtil.groovy
@@ -1,0 +1,31 @@
+package com.apgsga.patch.service.client
+
+class TestUtil {
+	
+	static def getLastProdRevisionLine(String lines) {
+		// Looking for the line which is for us interesting -> should contain "lastProdRevision"
+		def searchedLine = null
+		lines.eachLine{ line ->
+			if (line != null) {
+				if(line.contains("lastProdRevision")) {
+					searchedLine = line
+				}
+			}
+		}
+		return searchedLine
+	}
+	
+	static def getRevisionLine(String lines) {
+		// Looking for the line which is for us interesting -> should contain "fromRetrieveRevision"
+		def searchedLine = null
+		lines.eachLine{ line ->
+			if (line != null) {
+				if(line.contains("fromRetrieveRevision")) {
+					searchedLine = line
+				}
+			}
+		}
+		return searchedLine
+	}
+
+}


### PR DESCRIPTION
Revision tasks have been moved into a specific client. That means, for following target options:

- sr 
- rr 
- pr 
- resr 
- rtr

In this first step, I only moved the tasks to a specific client. Exchanging data via a standard JSON file, eventually setting up a Revision interface etc ... can be done afterwards (I just would like to first test that nothing has been forgotten...)