### PR TITLE
Preparation for Restarting Patch Pipeline

### DIFF
--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/client/utils/TargetSystemMappings.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/client/utils/TargetSystemMappings.groovy
@@ -1,0 +1,31 @@
+package com.apgsga.patch.client.utils
+
+import groovy.json.JsonSlurper
+
+public class TargetSystemMappings {
+
+	private TargetSystemMappings() {
+	}
+
+	static def load(config) {
+		def mappingFileName = config.target.system.mapping.file.name
+		def configDir = config.config.dir
+		def targetSystemMappingsFilePath = "${configDir}/${mappingFileName}"
+		def targetSystemFile = new File(targetSystemMappingsFilePath)
+		def jsonSystemTargets = new JsonSlurper().parseText(targetSystemFile.text)
+		def targetSystemMappings = [:]
+		jsonSystemTargets.targetSystems.find( { a ->  a.stages.find( { targetSystemMappings.put("${a.name}${it.toState}".toString(),"${it.code}") })} )
+		return targetSystemMappings
+	}
+	
+	static def findStatus(config, toStatus) {
+		def stateMappings = [:]
+		load(config).targetSystems.find( { a ->  a.stages.find( { stateMappings.put("${a.name}${it.toState}".toString(),"${it.code}") })} )
+		def statusNum = stateMappings[toStatus]
+		if (statusNum == null) {
+			println "Error , no Status mapped for ${toStatus}"
+			null
+		}
+		statusNum
+	}
+}

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/client/utils/TargetSystemMappings.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/client/utils/TargetSystemMappings.groovy
@@ -1,31 +1,36 @@
 package com.apgsga.patch.client.utils
 
 import groovy.json.JsonSlurper
+import groovy.transform.Synchronized
 
+@Singleton()
 public class TargetSystemMappings {
+	
+	def targetSystemMappings
 
-	private TargetSystemMappings() {
-	}
-
-	static def load(config) {
-		def mappingFileName = config.target.system.mapping.file.name
-		def configDir = config.config.dir
-		def targetSystemMappingsFilePath = "${configDir}/${mappingFileName}"
-		def targetSystemFile = new File(targetSystemMappingsFilePath)
-		def jsonSystemTargets = new JsonSlurper().parseText(targetSystemFile.text)
-		def targetSystemMappings = [:]
-		jsonSystemTargets.targetSystems.find( { a ->  a.stages.find( { targetSystemMappings.put("${a.name}${it.toState}".toString(),"${it.code}") })} )
+	def get() {
 		return targetSystemMappings
 	}
 	
-	static def findStatus(config, toStatus) {
-		def stateMappings = [:]
-		load(config).targetSystems.find( { a ->  a.stages.find( { stateMappings.put("${a.name}${it.toState}".toString(),"${it.code}") })} )
-		def statusNum = stateMappings[toStatus]
+	def findStatus(toStatus) {
+		def statusNum = targetSystemMappings[toStatus] 
 		if (statusNum == null) {
 			println "Error , no Status mapped for ${toStatus}"
 			null
 		}
 		statusNum
 	}
+	
+	@Synchronized
+	def load(config) {
+		def mappingFileName = config.target.system.mapping.file.name
+		def configDir = config.config.dir
+		def targetSystemMappingsFilePath = "${configDir}/${mappingFileName}"
+		def targetSystemFile = new File(targetSystemMappingsFilePath)
+		def jsonSystemTargets = new JsonSlurper().parseText(targetSystemFile.text)
+		targetSystemMappings = [:]
+		jsonSystemTargets.targetSystems.find( { a ->  a.stages.find( { targetSystemMappings.put("${a.name}${it.toState}".toString(),"${it.code}") })} )
+	}
+	
+
 }

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchCli.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchCli.groovy
@@ -1,21 +1,19 @@
 package com.apgsga.patch.service.client
 
 
-import org.apache.commons.logging.Log
-import org.apache.commons.logging.LogFactory
 import org.codehaus.groovy.runtime.StackTraceUtils
 import org.springframework.core.io.ClassPathResource
 
 import com.apgsga.microservice.patch.api.DbModules
 import com.apgsga.microservice.patch.api.Patch
 import com.apgsga.microservice.patch.api.ServicesMetaData
-import com.apgsga.patch.service.client.db.PatchDbClient
+import com.apgsga.patch.client.utils.TargetSystemMappings
 import com.fasterxml.jackson.databind.ObjectMapper
 
 import groovy.json.JsonSlurper
 
 class PatchCli {
-	
+
 	public static PatchCli create() {
 		def patchCli = new PatchCli()
 		return patchCli
@@ -24,8 +22,8 @@ class PatchCli {
 	private PatchCli() {
 		super();
 	}
-	
-	def validComponents = ["db", "aps", "mockdb", "nil"]
+
+	def validComponents = [ "aps", "nil"]
 	def validate = true
 	def config
 
@@ -42,68 +40,69 @@ class PatchCli {
 			return cmdResults
 		}
 		try {
+			def patchClient = new PatchServiceClient(config)
 			if (options.l) {
-				def result = uploadPatchFiles(options)
+				def result = uploadPatchFiles(patchClient,options)
 				cmdResults.results['l'] = result
 			}
 			if (options.d) {
-				def result = downloadPatchFiles(options)
+				def result = downloadPatchFiles(patchClient,options)
 				cmdResults.results['d'] =  result
 			}
 			if (options.e) {
-				def result = patchExists(options)
+				def result = patchExists(patchClient,options)
 				cmdResults.results['e'] =  result
 			}
 			if (options.fs) {
-				def result = findById(options)
+				def result = findById(patchClient,options)
 				cmdResults.results['f'] = result
 			}
 			if (options.a) {
-				def result = findAndPrintAllPatchIds()
+				def result = findAndPrintAllPatchIds(patchClient,options)
 				cmdResults.results['a'] =  result
 			}
 			if (options.r) {
-				def result = removePatch(options)
+				def result = removePatch(patchClient,options)
 				cmdResults.results['r'] =  result
 			}
 			if (options.s) {
-				def result = uploadPatch(options)
+				def result = uploadPatch(patchClient,options)
 				cmdResults.results['s']=  result
 			}
 			if (options.sa) {
-				def result = savePatch(options)
+				def result = savePatch(patchClient,options)
 				cmdResults.results['sa']=  result
 			}
 			if (options.dd) {
-				def result = downloadDbModules(options)
+				def result = downloadDbModules(patchClient,options)
 				cmdResults.results['dd'] = result
 			}
 			if (options.ud) {
-				def result = uploadDbModules(options)
+				def result = uploadDbModules(patchClient,options)
 				cmdResults.results['ud'] = result
 			}
 			if (options.dm) {
-				def result = downloadServiceMetaData(options)
+				def result = downloadServiceMetaData(patchClient,options)
 				cmdResults.results['dm'] = result
 			}
 			if (options.um) {
-				def result = uploadServiceMetaData(options)
+				def result = uploadServiceMetaData(patchClient,options)
 				cmdResults.results['um'] = result
 			}
 			if (options.sta) {
-				def result = stateChangeAction(options)
+				def result = stateChangeAction(patchClient,options)
 				cmdResults.results['sta'] = result
 			}
 			if (options.la) {
-				def result = listAllFiles(options)
+				def result = listAllFiles(patchClient,options)
 				cmdResults.results['la'] = result
 			}
 			if (options.lf) {
-				def result = listFiles(options)
+				def result = listFiles(patchClient,options)
 				cmdResults.results['lf'] = result
 			}
 			if (options.oc) {
-				def result = onClone(options)
+				def result = onClone(patchClient,options)
 				cmdResults.results['oc'] = result
 			}
 			if (options.cr) {
@@ -111,7 +110,7 @@ class PatchCli {
 				cmdResults.results['cr'] = result
 			}
 			if (options.cm) {
-				def result = cleanLocalMavenRepo()
+				def result = cleanLocalMavenRepo(patchClient,options)
 				cmdResults.results['cm'] = result
 			}
 			cmdResults.returnCode = 0
@@ -120,12 +119,10 @@ class PatchCli {
 			System.err.println "Server Error ccurred on ${e.errorMessage.timestamp} : ${e.errorMessage.errorText} "
 			cmdResults.results['error'] = e.errorMessage
 			return cmdResults
-
 		} catch (AssertionError e) {
 			System.err.println "Client Error ccurred ${e.message} "
 			cmdResults.results['error'] = e.message
 			return cmdResults
-
 		} catch (Exception e) {
 			System.err.println " Unhandling Exception occurred "
 			System.err.println e.toString()
@@ -134,24 +131,24 @@ class PatchCli {
 			return cmdResults
 		}
 	}
-	
+
 	private def parseConfig() {
 		ClassPathResource res = new ClassPathResource('apscli.properties')
 		assert res.exists() : "apscli.properties doesn't exist or is not accessible!"
 		ConfigObject conf = new ConfigSlurper(profile).parse(res.URL);
 		return conf
 	}
-	
+
 	private getProfile() {
 		def apsCliEnv = System.getProperty("apscli.env")
 		// If apscli.env is not define, we assume we're testing
 		def prof =  apsCliEnv ?: "test"
 		return prof
 	}
-	
+
 	def validateOpts(args) {
 		// TODO JHE: Add oc, sr, rr and rtr description here.
-		def cli = new CliBuilder(usage: 'apspli.sh [-u <url>] [-h] [-[l|d|dd|dm] <directory>]  [-[e|r] <patchnumber>] [-[s|sa|ud|um] <file>] [-f <patchnumber,directory>] [-sta <patchnumber,toState,[aps,db,nil]]')
+		def cli = new CliBuilder(usage: 'apspli.sh [-u <url>] [-h] [-[l|d|dd|dm] <directory>]  [-[e|r] <patchnumber>] [-[s|sa|ud|um] <file>] [-f <patchnumber,directory>] [-sta <patchnumber,toState,[aps]]')
 		cli.formatter.setDescPadding(0)
 		cli.formatter.setLeftPadding(0)
 		cli.formatter.setWidth(100)
@@ -171,10 +168,11 @@ class PatchCli {
 			um longOpt: 'uploadServicesMeta', args:1, argName: 'file', 'Upload ServiceMetaData from <file> to server', required: false
 			la longOpt: 'listAllFiles', 'List all files on server', required: false
 			lf longOpt: "listFiles", args:1, argName: 'prefix', 'List all files on server with prefix', required: false
-			// TODO (CHE,13.9) Seperate Db Part into own Cli, needs to be coordinated with current Patch System (PatchOMat)
-			sta longOpt: 'stateChange', args:3, valueSeparator: ",", argName: 'patchNumber,toState,component', 'Notfiy State Change for a Patch with <patchNumber> to <toState> to a <component> , where <component> can be service,db or null ', required: false
+			// TODO (CHE,13.9) Get rid of the component parameter, needs to be coordinated with current Patch System (PatchOMat)
+			sta longOpt: 'stateChange', args:3, valueSeparator: ",", argName: 'patchNumber,toState,component', 'Notfiy State Change for a Patch with <patchNumber> to <toState> to a <component> , where <component> can only be aps ', required: false
 			oc longOpt: 'onclone', args:1, argName: 'target', 'Call Patch Service onClone REST API', required: false
 			cm longOpt: 'cleanLocalMavenRepo', "Clean local Maven Repo used bei service", required: false
+			// TODO (JHE, CHE, 12.9 ) move this to own cli
 			cr longOpt: 'cleanReleases', args:1, argName: 'target', 'Clean release Artifacts for a given target on Artifactory', required: false
 		}
 
@@ -190,10 +188,10 @@ class PatchCli {
 		if (!validate) {
 			return options
 		}
-		
+
 		if (!options | options.h| options.getOptions().size() == 0) {
 			cli.usage()
-			def validToStates = getTargetSystemMappings().keySet()
+			def validToStates = TargetSystemMappings.load(config).keySet()
 			println "Valid toStates are: ${validToStates}"
 			println "Valid components are: ${validComponents}"
 			return null
@@ -282,12 +280,9 @@ class PatchCli {
 				error = true
 			}
 		}
-		if (options.db && !options.sta) {
-			println "No need to have a db configuration, if not using sta"
-		}
 		if (options.sta) {
 			if (options.stas.size() != 3 ) {
-				println "Option sta needs 3 arguments: <patchNumber,toState,[db,aps,nil]>"
+				println "Option sta needs 3 arguments: <patchNumber,toState, aps]>"
 				error = true
 			}
 			def patchNumber = options.stas[0]
@@ -296,7 +291,7 @@ class PatchCli {
 				error = true
 			}
 			def toState = options.stas[1]
-			def validToStates = getTargetSystemMappings().keySet()
+			def validToStates = TargetSystemMappings.load(config).keySet()
 			if (!validToStates.contains(toState) ) {
 				println "ToState ${toState} not valid: needs to be one of ${validToStates}"
 				error = true
@@ -306,14 +301,6 @@ class PatchCli {
 				println "Component ${component} not valid: needs to be one of ${validComponents}"
 				error = true
 			}
-			if (options.db) {
-				def dbConfigFile = new File(options.db)
-				if (!dbConfigFile.exists() || !dbConfigFile.isFile()) {
-					println "Db Configfile ${dbConfigFile} not valid: does'nt exist or isn't a file"
-					error = true
-				}
-			}
-
 		}
 		if (options.e) {
 			if (!options.e.isInteger()) {
@@ -339,27 +326,15 @@ class PatchCli {
 		}
 		options
 	}
-	
-	def cleanLocalMavenRepo() {
-		def patchClient = new PatchServiceClient(config)
+
+	def cleanLocalMavenRepo(def patchClient) {
 		def cmdResult = new Expando()
 		patchClient.cleanLocalMavenRepo();
 		cmdResult
 	}
-	
-	def getTargetSystemMappings() {
-		def mappingFileName = config.target.system.mapping.file.name
-		def configDir = config.config.dir
-		def targetSystemMappingsFilePath = "${configDir}/${mappingFileName}"
-		def targetSystemFile = new File(targetSystemMappingsFilePath)
-		def jsonSystemTargets = new JsonSlurper().parseText(targetSystemFile.text)
-		def targetSystemMappings = [:]
-		jsonSystemTargets.targetSystems.find( { a ->  a.stages.find( { targetSystemMappings.put("${a.name}${it.toState}".toString(),"${it.code}") })} )
-		return targetSystemMappings
-	}
-	
-	def stateChangeAction(def options) {
-		def patchClient = new PatchServiceClient(config)
+
+
+	def stateChangeAction(def patchClient,def options) {
 		def cmdResult = new Expando()
 		def patchNumber = options.stas[0]
 		def toState = options.stas[1]
@@ -369,29 +344,24 @@ class PatchCli {
 		cmdResult.component = component
 		if (component.equals("aps")) {
 			patchClient.executeStateTransitionAction(patchNumber,toState)
-		} else if (component.equals("db") || component.equals("mockdb")) {
-			def dbcli = new PatchDbClient(component,getTargetSystemMappings())
-			def jdbcConfigFule = new File(config.ops.groovy.file.path)
-			def defaultJdbcConfig = new ConfigSlurper().parse(jdbcConfigFule.toURI().toURL())
-			dbcli.executeStateTransitionAction(defaultJdbcConfig, patchNumber, toState)
 		} else {
 			println "Skipping State change Processing for ${patchNumber}"
 		}
 		return cmdResult
 	}
 
-	def findById(def options) {
+	def findById(def patchClient,def options) {
 		def cmdResult = new Expando()
 		def patchNumber = options.fs[0]
 		def dirName = options.fs[1]
-		def found = retrieveAndWritePatch(patchNumber, dirName)
+		def found = retrieveAndWritePatch(patchNumber, dirName, patchClient)
 		cmdResult.patchNumber = patchNumber
 		cmdResult.dirName = dirName
 		cmdResult.exists = found
 		return cmdResult
 	}
 
-	def downloadPatchFiles(def options) {
+	def downloadPatchFiles(def patchClient,def options) {
 		def cmdResult = new Expando()
 		List<String> ids =  patchClient.findAllPatchIds()
 		ids.each { id ->
@@ -402,32 +372,28 @@ class PatchCli {
 		return cmdResult
 	}
 
-	def findAndPrintAllPatchIds() {
-		def patchClient = new PatchServiceClient(config)
+	def findAndPrintAllPatchIds(def patchClient,def options) {
 		List<String> ids =  patchClient.findAllPatchIds()
 		println "All Patch Ids: ${ids}"
 		def cmdResult = new Expando()
 		cmdResult.patchNumbers = ids
 	}
 
-	def listAllFiles(def options) {
-		def patchClient = new PatchServiceClient(config)
+	def listAllFiles(def patchClient,def options) {
 		List<String> files =  patchClient.listAllFiles()
 		println "All Files on server: ${files}"
 		def cmdResult = new Expando()
 		cmdResult.files = files
 	}
 
-	def listFiles(def options) {
-		def patchClient = new PatchServiceClient(config)
+	def listFiles(def patchClient,def options) {
 		List<String> files =  patchClient.listFiles(options.lf)
 		println "Files with ${options.lf} as prefix on server: ${files}"
 		def cmdResult = new Expando()
 		cmdResult.files = files
 	}
 
-	def patchExists(def options) {
-		def patchClient = new PatchServiceClient(config)
+	def patchExists(def patchClient,def options) {
 		def exists = patchClient.patchExists(options.e)
 		println "Patch ${options.e} exists is: ${exists} "
 		def cmdResult = new Expando()
@@ -435,8 +401,7 @@ class PatchCli {
 		return cmdResult
 	}
 
-	def savePatch(def options) {
-		def patchClient = new PatchServiceClient(config)
+	def savePatch(def patchClient,def options) {
 		patchClient.save(new File(options.sa), Patch.class)
 		def cmdResult = new Expando()
 		cmdResult.patchFile = options.sa
@@ -444,8 +409,7 @@ class PatchCli {
 	}
 
 
-	def uploadPatch(def options) {
-		def patchClient = new PatchServiceClient(config)
+	def uploadPatch(def patchClient,def options) {
 		patchClient.savePatch(new File(options.s), Patch.class)
 		def cmdResult = new Expando()
 		cmdResult.patchFile = options.s
@@ -453,12 +417,11 @@ class PatchCli {
 	}
 
 
-	def removePatch(def options) {
-		def patchClient = new PatchServiceClient(config)
+	def removePatch(def patchClient,def options) {
 		println "Reading: ${options.r} to remove from server"
 		Patch patchData = patchClient.findById(options.r)
 		println "Removing Patch ${options.r}"
-	    assert patchData != null : "Patch ${options.r} to remove not found"
+		assert patchData != null : "Patch ${options.r} to remove not found"
 		patchClient.removePatch(patchData)
 		println "Remove Patch ${options.r} done."
 		def cmdResult = new Expando();
@@ -467,8 +430,7 @@ class PatchCli {
 		return cmdResult
 	}
 
-	def retrieveAndWritePatch(def id, def file) {
-		def patchClient = new PatchServiceClient(config)
+	def retrieveAndWritePatch(def patchClient,def id, def file) {
 		println "Writting: ${id} to ${file}"
 		def patchData = patchClient.findById(id)
 		if (patchData == null) {
@@ -480,8 +442,7 @@ class PatchCli {
 		return true
 	}
 
-	def uploadPatchFiles(def options) {
-		def patchClient = new PatchServiceClient(config)
+	def uploadPatchFiles(def patchClient,def options) {
 		def found = false
 		def cmdResult = new Expando()
 		cmdResult.fileNames = []
@@ -499,8 +460,7 @@ class PatchCli {
 		return cmdResult
 	}
 
-	def downloadDbModules(def options) {
-		def patchClient = new PatchServiceClient(config)
+	def downloadDbModules(def patchClient,def options) {
 		println "Downloading Dbmodules to ${options.dd}"
 		def cmdResult = new Expando()
 		def dbmodules =  patchClient.getDbModules()
@@ -518,16 +478,14 @@ class PatchCli {
 		return cmdResult
 	}
 
-	def uploadDbModules(def options) {
-		def patchClient = new PatchServiceClient(config)
+	def uploadDbModules(def patchClient,def options) {
 		println "Uploading Dbmodules from ${options.ud}"
 		ObjectMapper mapper = new ObjectMapper();
 		def dbModules = mapper.readValue(new File("${options.ud}"), DbModules.class)
 		patchClient.saveDbModules(dbModules)
 	}
 
-	def downloadServiceMetaData(def options) {
-		def patchClient = new PatchServiceClient(config)
+	def downloadServiceMetaData(def patchClient,def options){
 		println "Downloading ServiceMetaData to ${options.dm}"
 		def cmdResult = new Expando()
 		def data =  patchClient.getServicesMetaData()
@@ -545,8 +503,7 @@ class PatchCli {
 		return cmdResult
 	}
 
-	def uploadServiceMetaData(def options) {
-		def patchClient = new PatchServiceClient(config)
+	def uploadServiceMetaData(def patchClient,def options) {
 		println "Uploading ServiceMetaData from ${options.um}"
 		ObjectMapper mapper = new ObjectMapper();
 		def serviceMetaData = mapper.readValue(new File("${options.um}"), ServicesMetaData.class)
@@ -554,8 +511,7 @@ class PatchCli {
 	}
 
 
-	def onClone(def options) {
-		def patchClient = new PatchServiceClient(config)
+	def onClone(def patchClient,def options) {
 		println "Performing onClone for ${options.ocs[0]}"
 		def target = options.ocs[0]
 		patchClient.onClone(target)

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchCli.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchCli.groovy
@@ -31,6 +31,7 @@ class PatchCli {
 		println "apscli running with ${profile} profile"
 		println args
 		config = parseConfig()
+		TargetSystemMappings.instance.load(config)
 		def cmdResults = new Expando();
 		cmdResults.returnCode = 1
 		cmdResults.results = [:]
@@ -191,7 +192,7 @@ class PatchCli {
 
 		if (!options | options.h| options.getOptions().size() == 0) {
 			cli.usage()
-			def validToStates = TargetSystemMappings.load(config).keySet()
+			def validToStates = TargetSystemMappings.instance.get().keySet()
 			println "Valid toStates are: ${validToStates}"
 			println "Valid components are: ${validComponents}"
 			return null
@@ -291,7 +292,7 @@ class PatchCli {
 				error = true
 			}
 			def toState = options.stas[1]
-			def validToStates = TargetSystemMappings.load(config).keySet()
+			def validToStates = TargetSystemMappings.instance.get().keySet()
 			if (!validToStates.contains(toState) ) {
 				println "ToState ${toState} not valid: needs to be one of ${validToStates}"
 				error = true
@@ -354,7 +355,7 @@ class PatchCli {
 		def cmdResult = new Expando()
 		def patchNumber = options.fs[0]
 		def dirName = options.fs[1]
-		def found = retrieveAndWritePatch(patchNumber, dirName, patchClient)
+		def found = retrieveAndWritePatch(patchClient, patchNumber, dirName )
 		cmdResult.patchNumber = patchNumber
 		cmdResult.dirName = dirName
 		cmdResult.exists = found

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbCli.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbCli.groovy
@@ -1,12 +1,20 @@
 package com.apgsga.patch.service.client.db
 
+import org.apache.commons.lang.exception.ExceptionUtils
 import org.codehaus.groovy.runtime.StackTraceUtils
 import org.springframework.core.io.ClassPathResource
 
+import com.apgsga.patch.client.utils.TargetSystemMappings
 import com.apgsga.patch.service.client.PatchClientServerException
 
 import groovy.sql.Sql
 
+/**
+ * This command line Tool  is used to make jdbc calls to the It21 database. 
+ * It is intended to be use in a automated scripting enviroment like Jenkins pipeline, which depend on standard output processing
+ * therefore care has been taken to avoid logging via standard output in the normal path of execution
+ *
+ */
 class PatchDbCli {
 
 	def config
@@ -19,14 +27,10 @@ class PatchDbCli {
 	}
 
 	def process(def args) {
-
-		println "apsDbCli running with ${profile} profile"
-		println args
-
 		config = parseConfig()
+		TargetSystemMappings.instance.load(config)
 		def cmdResults = new Expando();
 		cmdResults.returnCode = 1
-		cmdResults.results = [:]
 		def options = validateOpts(args)
 		if (!options) {
 			cmdResults.returnCode = 0
@@ -36,30 +40,33 @@ class PatchDbCli {
 			def jdbcConfigFile = new File(config.ops.groovy.file.path)
 			def defaultJdbcConfig = new ConfigSlurper().parse(jdbcConfigFile.toURI().toURL())
 			def dbConnection = Sql.newInstance(defaultJdbcConfig.db.url, defaultJdbcConfig.db.user, defaultJdbcConfig.db.passwd)
-			def dbCli = new PatchDbClient(dbConnection, null)
+			def dbCli = new PatchDbClient(dbConnection, config)
 			if(options.lpac) {
 				def status = options.lpacs[0]
-				def result = dbCli.listPatchAfterClone(status,config.postclone.list.patch.file.path)
-				cmdResults.results['lpac'] = result
+				cmdResults.result = dbCli.listPatchAfterClone(status,config.postclone.list.patch.file.path)
 			} else if (options.rsta) {
-				def result = dbCli.retrieveCurrentPatchState(options.rsta[0])
-				cmdResults.results['rsta'] = result
+				cmdResults.status  = dbCli.retrievePredecessorStatesForPatch(options.rsta)
+			} else if (options.sta) {
+				def patchNumber = options.stas[0]
+				def toState = options.stas[1]
+				cmdResults.dbResult = dbCli.executeStateTransitionAction(patchNumber,toState)
 			}
 			cmdResults.returnCode = 0
 			return cmdResults
 		} catch (PatchClientServerException e) {
 			System.err.println "Server Error ccurred on ${e.errorMessage.timestamp} : ${e.errorMessage.errorText} "
-			cmdResults.results['error'] = e.errorMessage
+			cmdResults.error = e.errorMessage
 			return cmdResults
 		} catch (AssertionError e) {
 			System.err.println "Client Error ccurred ${e.message} "
-			cmdResults.results['error'] = e.message
+			println ExceptionUtils.getFullStackTrace(e)
+			cmdResults.error = e.message
 			return cmdResults
 		} catch (Exception e) {
-			System.err.println " Unhandling Exception occurred "
+			System.err.println "Unhandeled Exception occurred "
 			System.err.println e.toString()
-			StackTraceUtils.printSanitizedStackTrace(e,new PrintWriter(System.err))
-			cmdResults.results['error'] = e
+			println ExceptionUtils.getFullStackTrace(e)
+			cmdResults.error = e
 			return cmdResults
 		}
 	}
@@ -79,7 +86,7 @@ class PatchDbCli {
 	}
 
 	private def validateOpts(def args) {
-		def cli = new CliBuilder(usage: 'apsdbpli.sh -[h|lpac]')
+		def cli = new CliBuilder(usage: 'apsdbpli.sh -[h|lpac|[rsta,patchNumber]')
 		cli.formatter.setDescPadding(0)
 		cli.formatter.setLeftPadding(0)
 		cli.formatter.setWidth(100)
@@ -87,7 +94,7 @@ class PatchDbCli {
 			h longOpt: 'help', 'Show usage information', required: false
 			lpac longOpt: 'listPatchAfterClone', args:1, argName: 'status', 'Get list of patches to be re-installed after a clone', required: false
 			rsta longOpt: 'retrievePatchStatus', args:1, argName: 'patchNumber', 'Get the Status for the Patch with PatchNumber', required: false
-			nsta longOpt: 'notifyPatchStatus', args:1, argName: 'patchNumber', 'Notify the Patch Status back to the Db', required: false
+			sta longOpt: 'stateChange', args:2, valueSeparator: ",", argName: 'patchNumber,toState', 'Notfiy State Change for a Patch with <patchNumber> to <toState> to the database', required: false
 		}
 
 		def options = cli.parse(args)
@@ -110,18 +117,31 @@ class PatchDbCli {
 				error = true
 			}
 		}
-		
+
 		if(options.rsta) {
-			if(options.rsta.size() != 1) {
-				println("Target status is required when fetching list of patch to be re-installed.")
-				error = true
-			}
 			if (!options.rsta.isInteger()) {
 				println "Patchnumber ${options.rsta} is not a Integer"
 				error = true
 			}
 		}
 
+		if (options.sta) {
+			if (options.stas.size() != 2 ) {
+				println "Option sta needs 2 arguments: <patchNumber,toState>>"
+				error = true
+			}
+			def patchNumber = options.stas[0]
+			if (!patchNumber.isInteger()) {
+				println "Patchnumber ${patchNumber} is not a Integer"
+				error = true
+			}
+			def toState = options.stas[1]
+			def validToStates = TargetSystemMappings.instance.get().keySet()
+			if (!validToStates.contains(toState) ) {
+				println "ToState ${toState} not valid: needs to be one of ${validToStates}"
+				error = true
+			}
+		}
 
 		if(error) {
 			cli.usage()

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbCli.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbCli.groovy
@@ -5,28 +5,25 @@ import org.springframework.core.io.ClassPathResource
 
 import com.apgsga.patch.service.client.PatchClientServerException
 
-import groovy.json.JsonBuilder
-import groovy.json.JsonOutput
 import groovy.sql.Sql
 
 class PatchDbCli {
-	
+
 	def config
-	
+
 	private PatchDbCli() {
 	}
-	
+
 	public static create() {
 		return new PatchDbCli()
 	}
-	
+
 	def process(def args) {
-		
+
 		println "apsDbCli running with ${profile} profile"
 		println args
-		
+
 		config = parseConfig()
-		
 		def cmdResults = new Expando();
 		cmdResults.returnCode = 1
 		cmdResults.results = [:]
@@ -36,10 +33,17 @@ class PatchDbCli {
 			return cmdResults
 		}
 		try {
+			def jdbcConfigFile = new File(config.ops.groovy.file.path)
+			def defaultJdbcConfig = new ConfigSlurper().parse(jdbcConfigFile.toURI().toURL())
+			def dbConnection = Sql.newInstance(defaultJdbcConfig.db.url, defaultJdbcConfig.db.user, defaultJdbcConfig.db.passwd)
+			def dbCli = new PatchDbClient(dbConnection, null)
 			if(options.lpac) {
 				def status = options.lpacs[0]
-				def result = listPatchAfterClone(status)
+				def result = dbCli.listPatchAfterClone(status,config.postclone.list.patch.file.path)
 				cmdResults.results['lpac'] = result
+			} else if (options.rsta) {
+				def result = dbCli.retrieveCurrentPatchState(options.rsta[0])
+				cmdResults.results['rsta'] = result
 			}
 			cmdResults.returnCode = 0
 			return cmdResults
@@ -47,12 +51,10 @@ class PatchDbCli {
 			System.err.println "Server Error ccurred on ${e.errorMessage.timestamp} : ${e.errorMessage.errorText} "
 			cmdResults.results['error'] = e.errorMessage
 			return cmdResults
-	
 		} catch (AssertionError e) {
 			System.err.println "Client Error ccurred ${e.message} "
 			cmdResults.results['error'] = e.message
 			return cmdResults
-	
 		} catch (Exception e) {
 			System.err.println " Unhandling Exception occurred "
 			System.err.println e.toString()
@@ -60,48 +62,22 @@ class PatchDbCli {
 			cmdResults.results['error'] = e
 			return cmdResults
 		}
-		
 	}
-	
-	private def listPatchAfterClone(def status) {
-		//Query db to get list of patch to be installed fora given status
-		def jdbcConfigFile = new File(config.ops.groovy.file.path)
-		def defaultJdbcConfig = new ConfigSlurper().parse(jdbcConfigFile.toURI().toURL())
-		// If we don't force sql to be a String, ${status} will be replace with a "?" at the time we run the query.
-		def String sql = "SELECT id FROM cm_patch_install_sequence_f WHERE ${status}=1 AND (produktion = 0 OR chronology > trunc(SYSDATE))"
-		def dbConnection = Sql.newInstance(defaultJdbcConfig.db.url, defaultJdbcConfig.db.user, defaultJdbcConfig.db.passwd)
-		def patchNumbers = []
-		dbConnection.eachRow(sql) { row ->
-			def rowId = row.ID
-			println "Patch ${rowId} added to the list of patch to be re-installed."
-			patchNumbers.add(rowId)
-		}
-		
-		def listPatchFile = new File(config.postclone.list.patch.file.path)
-		
-		if(listPatchFile.exists()) {
-			listPatchFile.delete()
-		}
-		
-		listPatchFile.write(new JsonBuilder(patchlist:patchNumbers).toPrettyString())
-		
-		return patchNumbers
-	}
-	
+
 	private def parseConfig() {
 		ClassPathResource res = new ClassPathResource('apscli.properties')
 		assert res.exists() : "apscli.properties doesn't exist or is not accessible!"
 		ConfigObject conf = new ConfigSlurper(profile).parse(res.URL);
 		return conf
 	}
-	
+
 	private getProfile() {
 		def apsCliEnv = System.getProperty("apscli.env")
 		// If apscli.env is not define, we assume we're testing
 		def prof =  apsCliEnv ?: "test"
 		return prof
 	}
-	
+
 	private def validateOpts(def args) {
 		def cli = new CliBuilder(usage: 'apsdbpli.sh -[h|lpac]')
 		cli.formatter.setDescPadding(0)
@@ -110,23 +86,24 @@ class PatchDbCli {
 		cli.with {
 			h longOpt: 'help', 'Show usage information', required: false
 			lpac longOpt: 'listPatchAfterClone', args:1, argName: 'status', 'Get list of patches to be re-installed after a clone', required: false
-			
+			rsta longOpt: 'retrievePatchStatus', args:1, argName: 'patchNumber', 'Get the Status for the Patch with PatchNumber', required: false
+			nsta longOpt: 'notifyPatchStatus', args:1, argName: 'patchNumber', 'Notify the Patch Status back to the Db', required: false
 		}
-		
+
 		def options = cli.parse(args)
 		def error = false;
-		
+
 		if (!options | options.getOptions().size() == 0) {
 			println "No option have been provided, please see the usage."
 			cli.usage()
 			return null
 		}
-		
+
 		if(options.h) {
 			cli.usage()
 			return null
 		}
-		
+
 		if(options.lpac) {
 			if(options.lpacs.size() != 1) {
 				println("Target status is required when fetching list of patch to be re-installed.")
@@ -134,12 +111,23 @@ class PatchDbCli {
 			}
 		}
 		
+		if(options.rsta) {
+			if(options.rsta.size() != 1) {
+				println("Target status is required when fetching list of patch to be re-installed.")
+				error = true
+			}
+			if (!options.rsta.isInteger()) {
+				println "Patchnumber ${options.rsta} is not a Integer"
+				error = true
+			}
+		}
+
+
 		if(error) {
 			cli.usage()
 			return null
 		}
-		
+
 		options
-		
 	}
 }

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbClient.groovy
@@ -1,32 +1,53 @@
 package com.apgsga.patch.service.client.db
+import com.apgsga.patch.client.utils.TargetSystemMappings
+
+import groovy.json.JsonBuilder
 import groovy.sql.Sql
 class PatchDbClient {
-	
-	def statusMap
-	def component
-	
-	private PatchDbClient(def component, def statusMap) {
+
+	def config
+	def dbConnection
+
+	private PatchDbClient(def dbConnection, def config) {
 		super();
-		this.component = component;
-		this.statusMap = statusMap
+		this.dbConnection = dbConnection;
+		this.config = config
 	}
 
-	public void executeStateTransitionAction(def dbProperties, def patchNumber, def toStatus) {
-		println "Statusmap: " + statusMap.toString()
-		def statusNum = statusMap[toStatus]
-		if (statusNum == null) {
-			println "Error , no Status mapped for ${toStatus}"
-			return
-		}
+	public void executeStateTransitionAction(def patchNumber, def toStatus) {
+		def statusNum = TargetSystemMappings.findStatus(config, toStatus); 
 		def sql = "update cm_patch_f set status = ${statusNum} where id = ${patchNumber}".toString()
-		println "Executing ${sql}"
-		if (component.equals("db")) {
-			def dbConnection = Sql.newInstance(dbProperties.db.url, dbProperties.db.user, dbProperties.db.passwd)
-			def result = dbConnection.execute(sql)
-			println "Done with result: ${result}"
-		} else {
-			println "Done with : ${component}"
+		def result = dbConnection.execute(sql)
+		println result
+	}
+
+	public def listPatchAfterClone(def status, def filePath) {
+		// If we don't force sql to be a String, ${status} will be replace with a "?" at the time we run the query.
+		def String sql = "SELECT id FROM cm_patch_install_sequence_f WHERE ${status}=1 AND (produktion = 0 OR chronology > trunc(SYSDATE))"
+		def patchNumbers = []
+		dbConnection.eachRow(sql) { row ->
+			def rowId = row.ID
+			println "Patch ${rowId} added to the list of patch to be re-installed."
+			patchNumbers.add(rowId)
 		}
 
+		// TODO (jhe, che, 19.9) have filePath passed as parameter and not preconfigured
+		// Or write it stdout , but without any other println
+		def listPatchFile = new File(filePath)
+
+		if(listPatchFile.exists()) {
+			listPatchFile.delete()
+		}
+
+		listPatchFile.write(new JsonBuilder(patchlist:patchNumbers).toPrettyString())
 	}
+
+	public def retrieveCurrentPatchState(def patchNumber) {
+		def sql = "select status from  cm_patch_f where id = ${patchNumber}".toString()
+		def result = dbConnection.firstRow(sql)
+		print result
+		result
+	}
+
+
 }

--- a/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/DbCliIntegrationTest.groovy
+++ b/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/DbCliIntegrationTest.groovy
@@ -26,6 +26,7 @@ class DbCliIntegrationTest extends Specification {
 		result.results.size() == 0
 	}
 	
+	// TODO (JHE, CHE, 19.9 ): This doesn't make really sense, what is tested? 
 	def "Patch DB Cli returns patch ids to be re-installed after a clone"() {
 		setup:
 			def patchDbCli = Stub(PatchDbCli.class)
@@ -36,6 +37,22 @@ class DbCliIntegrationTest extends Specification {
 			result = patchDbCli.process(["-lpac", "Informatiktest"])
 		then:
 			result != null
+	}
+	
+	def "Patch DB Cli returns patch ids to be re-installed after a clone, real"() {
+		setup:
+			def patchDbCli = PatchDbCli.create()
+			def result
+			def outputFile = new File("src/test/resources/patchToBeReinstalled.json")
+		when:
+			result = patchDbCli.process(["-lpac", "Informatiktest"])
+		then:
+			result != null
+			outputFile.exists()
+			def patchList = new JsonSlurper().parseText(outputFile.text)
+			println "content of outputfile : ${patchList}"
+		cleanup:
+			outputFile.delete()
 	}
 
 }

--- a/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/DbCliIntegrationTest.groovy
+++ b/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/DbCliIntegrationTest.groovy
@@ -1,58 +1,142 @@
 package com.apgsga.patch.service.client
 
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment
+import static com.apgsga.patch.service.client.DbCliIntegrationTest.dbAvailable
+import static com.apgsga.patch.service.client.DbCliIntegrationTest.patchExists
+
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.annotation.DirtiesContext.ClassMode
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 
-import com.apgsga.microservice.patch.server.MicroPatchServer
 import com.apgsga.patch.service.client.db.PatchDbCli
 
 import groovy.json.JsonSlurper
-import spock.lang.Ignore
+import groovy.sql.Sql
+import spock.lang.Requires
 import spock.lang.Specification
 
-@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
-@TestPropertySource(locations = "application-test.properties")
+
 class DbCliIntegrationTest extends Specification {
 	
+
 	def "Patch DB Cli should print out help without errors"() {
 		def result = PatchDbCli.create().process(["-h"])
 		expect: "PatchDbCli returns null in case of help only (-h)"
 		result != null
 		result.returnCode == 0
-		result.results.size() == 0
 	}
 	
-	// TODO (JHE, CHE, 19.9 ): This doesn't make really sense, what is tested? 
+	@Requires({dbAvailable()})
 	def "Patch DB Cli returns patch ids to be re-installed after a clone"() {
 		setup:
-			def patchDbCli = Stub(PatchDbCli.class)
-			def patchNumbers = [1234,5678]
-			patchDbCli.listPatchAfterClone("Informatiktest") >> patchNumbers
-			def result
+		def patchDbCli = PatchDbCli.create()
+		def result
+		def outputFile = new File("src/test/resources/patchToBeReinstalled.json")
 		when:
-			result = patchDbCli.process(["-lpac", "Informatiktest"])
+		result = patchDbCli.process(["-lpac", "Informatiktest"])
 		then:
-			result != null
+		result != null
+		result.returnCode == 0
+		outputFile.exists()
+		def patchList = new JsonSlurper().parseText(outputFile.text)
+		println "content of outputfile : ${patchList}"
+		cleanup:
+		outputFile.delete()
+	}
+
+
+	@Requires({patchExists("4969")})
+	def "Patch DB Cli  returns Status of Patch"() {
+		setup:
+		def patchDbCli = PatchDbCli.create()
+		def result
+		def savedOut
+		def buffer
+		when:
+		savedOut = System.out;
+		buffer = new ByteArrayOutputStream()
+		System.setOut(new PrintStream(buffer))
+		result = patchDbCli.process(["-rsta", "4969"])
+		System.setOut(savedOut)
+		then:
+		result != null
+		result.returnCode == 0
+		result.status == 80
+		buffer.toString().trim() == "80"
+
 	}
 	
-	def "Patch DB Cli returns patch ids to be re-installed after a clone, real"() {
+	@Requires({dbAvailable()})
+	def "Patch DB Cli tries to retrieve Status of non existing Patch"() {
 		setup:
-			def patchDbCli = PatchDbCli.create()
-			def result
-			def outputFile = new File("src/test/resources/patchToBeReinstalled.json")
+		def patchDbCli = PatchDbCli.create()
+		def result
 		when:
-			result = patchDbCli.process(["-lpac", "Informatiktest"])
+		result = patchDbCli.process(["-rsta", "99999"])
 		then:
-			result != null
-			outputFile.exists()
-			def patchList = new JsonSlurper().parseText(outputFile.text)
-			println "content of outputfile : ${patchList}"
-		cleanup:
-			outputFile.delete()
+		result != null
+		result.returnCode == 1
+		result.error.getClass().getName() == "java.lang.IllegalArgumentException"
+		result.error.message == "Patch with Id: 99999 not found"
 	}
+	
+	@Requires({patchExists("5799")})
+	def "Patch DB Cli  update status of Patch"() {
+		setup:
+		def db = dbConnection("cm", "cm_pass");
+		def dbResult = db.execute('update cm_patch_t set status = 1 where id = :id',["id":5799])
+		def patchDbCli = PatchDbCli.create()
+		def result
+		def savedOut
+		def buffer
+		when:
+		savedOut = System.out;
+		buffer = new ByteArrayOutputStream()
+		System.setOut(new PrintStream(buffer))
+		result = patchDbCli.process(["-sta", "5799,EntwicklungInstallationsbereit"])
+		System.setOut(savedOut)
+		then:
+		result != null
+		result.returnCode == 0
+		result.dbResult == false
+		buffer.toString().trim() == "true"
+
+	}
+	
+
+	// Preconditions for Tests used via Spack @Require
+	static def dbConnection() {
+		def jdbcConfigFile = new File("src/test/resources/config/ops.groovy")
+		def defaultJdbcConfig = new ConfigSlurper().parse(jdbcConfigFile.toURI().toURL())
+		def dbConnection = Sql.newInstance(defaultJdbcConfig.db.url, defaultJdbcConfig.db.user, defaultJdbcConfig.db.passwd)
+		dbConnection
+	}
+	
+	static def dbConnection(String user, String passwd) {
+		def jdbcConfigFile = new File("src/test/resources/config/ops.groovy")
+		def defaultJdbcConfig = new ConfigSlurper().parse(jdbcConfigFile.toURI().toURL())
+		def dbConnection = Sql.newInstance(defaultJdbcConfig.db.url, user, passwd)
+		dbConnection
+	}
+
+	public static boolean dbAvailable() {
+		try {
+			dbConnection()
+			return true;
+		} catch (Exception e) {
+			return false
+		}
+	}
+	public static boolean patchExists(String patchNumber) {
+		try {
+			def id = patchNumber as Long
+			def db = dbConnection()
+			def sql = 'select status from  cm_patch_f where id = :patchNumber';
+			def result = db.firstRow(sql, [patchNumber:id])
+			return result != null;
+		} catch (Exception e) {
+			return false
+		}
+	}
+	
 
 }

--- a/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/PatchCliIntegrationExceptionHandlingTests.groovy
+++ b/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/PatchCliIntegrationExceptionHandlingTests.groovy
@@ -20,7 +20,7 @@ import spock.lang.Specification;
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT, classes = [MicroPatchServer.class ])
 @TestPropertySource(locations = "application-test.properties")
 @ActiveProfiles("test,mock,mockMavenRepo,groovyactions")
-public class IntegrationExceptionHandlingTests extends Specification {
+public class PatchCliIntegrationExceptionHandlingTests extends Specification {
 
 	private static def DEFAULT_CONFIG_OPT = ["-c", "src/test/resources/config"]
 

--- a/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/PatchCliIntegrationTest.groovy
+++ b/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/PatchCliIntegrationTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification;
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT, classes = [MicroPatchServer.class ])
 @TestPropertySource(locations = "application-test.properties")
 @ActiveProfiles("test,mock,mockMavenRepo,groovyactions")
-public class IntegrationTest extends Specification {
+public class PatchCliIntegrationTest extends Specification {
 
 	@Value('${json.db.location}')
 	private String dbLocation;
@@ -297,21 +297,6 @@ public class IntegrationTest extends Specification {
 		result.returnCode == 0
 	}
 
-
-	def "Patch Cli valid State Change Action for config db with config file"() {
-		setup:
-		def client = PatchCli.create()
-		when:
-		def preCondResult = client.process(["-s", "src/test/resources/Patch5401.json"])
-		def result = client.process(["-sta", "5401,EntwicklungInstallationsbereit,mockdb"])
-		then:
-		preCondResult != null
-		preCondResult.returnCode == 0
-		result != null
-		result.returnCode == 0
-		cleanup:
-		repo.clean()
-	}
 
 	def "Patch Cli validate Artifact names from version"() {
 		setup:

--- a/apg-patch-service-cmdclient/src/test/resources/config/TargetSystemMappings.json
+++ b/apg-patch-service-cmdclient/src/test/resources/config/TargetSystemMappings.json
@@ -6,17 +6,18 @@
             "typeInd": "T",
             "stages": [
                 {
-                    "name": "startPipelineAndTag",
-                    "toState": "Installationsbereit",
-                    "code": 2,
-                    "implcls": "com.apgsga.microservice.patch.server.impl.EntwicklungInstallationsbereitAction"
-                },
-                {
                     "name": "cancel",
                     "toState": "",
                     "code": 0,
                     "implcls": "com.apgsga.microservice.patch.server.impl.PipelineInputAction"
+                },
+                {
+                    "name": "startPipelineAndTag",
+                    "toState": "Installationsbereit",
+                    "code": 2,
+                    "implcls": "com.apgsga.microservice.patch.server.impl.EntwicklungInstallationsbereitAction"
                 }
+
             ]
         },
         {

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClientImpl.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClientImpl.java
@@ -13,6 +13,7 @@ import org.springframework.core.task.TaskExecutor;
 
 import com.apgsga.microservice.patch.api.Patch;
 import com.apgsga.microservice.patch.exceptions.ExceptionFactory;
+import com.apgsga.microservice.patch.exceptions.PatchServiceRuntimeException;
 import com.google.common.collect.Maps;
 import com.offbytwo.jenkins.JenkinsServer;
 import com.offbytwo.jenkins.model.Build;
@@ -95,8 +96,8 @@ public class JenkinsClientImpl implements JenkinsClient {
 			Map<String, String> jobParm = Maps.newHashMap();
 			jobParm.put(TOKEN_CONS, jobName);
 			jobParm.put("PARAMETER", patchFile.getAbsolutePath());
-			jobParm.put("RESTART" , restart ? "TRUE" : "FALSE");
-		
+			jobParm.put("RESTART", restart ? "TRUE" : "FALSE");
+
 			// TODO (jhe , che , 12.12. 2017) : hangs, when job fails
 			// immediately
 			LOGGER.info("Triggering Pipeline Job and waiting until Building " + jobName + " with Paramter: "
@@ -138,7 +139,8 @@ public class JenkinsClientImpl implements JenkinsClient {
 
 	@Override
 	public void processInputAction(Patch patch, String targetName, String stage) {
-		String action = stage.equals(CANCEL_CONS) ? stage : PATCH_CONS + patch.getPatchNummer() + stage + targetName + OK_CONS;
+		String action = stage.equals(CANCEL_CONS) ? stage
+				: PATCH_CONS + patch.getPatchNummer() + stage + targetName + OK_CONS;
 		JenkinsServer jenkinsServer = null;
 		try {
 			jenkinsServer = new JenkinsServer(new URI(jenkinsUrl), jenkinsUser, jenkinsUserAuthKey);
@@ -161,7 +163,7 @@ public class JenkinsClientImpl implements JenkinsClient {
 			throws IOException, InterruptedException {
 		while (waitForAndProcessInput(patch, action, lastBuild)) {
 			// Loops with condition
-			
+
 		}
 	}
 
@@ -193,7 +195,7 @@ public class JenkinsClientImpl implements JenkinsClient {
 						"JenkinsPatchClientImpl.inputActionForPipeline.error",
 						new Object[] { patch.toString(), action });
 			}
-			return false; 
+			return false;
 		}
 	}
 
@@ -230,6 +232,9 @@ public class JenkinsClientImpl implements JenkinsClient {
 				throw ExceptionFactory.createPatchServiceRuntimeException("JenkinsAdminClientImpl.startPipeline.error",
 						new Object[] { target, jobName, details.getConsoleOutputText() });
 			}
+		} catch (PatchServiceRuntimeException e) {
+			throw e;
+
 		} catch (Exception e) {
 			throw ExceptionFactory.createPatchServiceRuntimeException("JenkinsAdminClientImpl.startPipeline.error",
 					new Object[] { e.getMessage(), target }, e);
@@ -258,8 +263,7 @@ public class JenkinsClientImpl implements JenkinsClient {
 		}
 		if (retryCnt >= DEFAULT_RETRY_COUNTS) {
 			throw ExceptionFactory.createPatchServiceRuntimeException(
-					"JenkinsPatchClientImpl.triggerPipelineJobAndWaitUntilBuilding.error",
-					new Object[] { jobName });
+					"JenkinsPatchClientImpl.triggerPipelineJobAndWaitUntilBuilding.error", new Object[] { jobName });
 		}
 		Build build = server.getBuild(queueItem);
 		retryCnt = 0;
@@ -280,8 +284,7 @@ public class JenkinsClientImpl implements JenkinsClient {
 			retryCnt++;
 		}
 		throw ExceptionFactory.createPatchServiceRuntimeException(
-				"JenkinsPatchClientImpl.triggerPipelineJobAndWaitUntilBuilding.error",
-				new Object[] { jobName });
+				"JenkinsPatchClientImpl.triggerPipelineJobAndWaitUntilBuilding.error", new Object[] { jobName });
 	}
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ project.ext {
 allprojects  {
 	apply plugin: 'maven'
 	group = 'com.apgsga.patchframework'
-	version  = '1.1.29'
+	version  = '1.1.30'
 }
 
 subprojects {


### PR DESCRIPTION
Refactored PatchDbCli - quite alot, thank god for the tests ;-) 

- All jdbc calls to the are now supported with PatchDbCli
- Moved the -sta Db Code of  PatchCli to here 
- Moved all application code to PatchDbClient , also listPatchAfterClone
- Added an option for Restart support for querying predecssor States, this not yet used and finished
- Refactored DbCliIntegrationTest.groovy to support conditional Testing against the Db , see @Requires option of Spock
- Cleaned up PatchDbcli and PatchCli some
- Important: Refactored so  that PatchDbCli doesn't write in ther normal execution path to stdout, needs to be asserted in the tests yet 
- So the assumption is that Standardout can be used for simple cases , see https://issues.jenkins-ci.org/browse/JENKINS-26133


@apgsga-jhe  i will be merging this before you can have a look at it ;-) 