### PR TITLE
Redo redesign

### DIFF
--- a/apg-patch-service-cmdclient/build.gradle
+++ b/apg-patch-service-cmdclient/build.gradle
@@ -91,7 +91,7 @@ def homeDir = "/opt/${finalName}"
 ospackage {
 	packageName = "${finalName}"
 	version = "${savedVersion}"
-	release = 6
+	release = 7
 	os = LINUX
 	type = BINARY
 	arch = NOARCH

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbCli.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbCli.groovy
@@ -11,7 +11,7 @@ import groovy.sql.Sql
 
 /**
  * This command line Tool  is used to make jdbc calls to the It21 database. 
- * It is intended to be use in a automated scripting enviroment like Jenkins pipeline, which depend on standard output processing
+ * It is intended to be used in a automated scripting enviroment like Jenkins pipeline, which depends on standard output processing
  * therefore care has been taken to avoid logging via standard output in the normal path of execution
  *
  */
@@ -45,7 +45,7 @@ class PatchDbCli {
 				def status = options.lpacs[0]
 				cmdResults.result = dbCli.listPatchAfterClone(status,config.postclone.list.patch.file.path)
 			} else if (options.rsta) {
-				cmdResults.result  = dbCli.retrievePredecessorStatesForPatch(options.rsta)
+				cmdResults.result  = dbCli.retrieveRedoToState(options.rsta)
 			} else if (options.sta) {
 				def patchNumber = options.stas[0]
 				def toState = options.stas[1]

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbClient.groovy
@@ -46,14 +46,13 @@ class PatchDbClient {
 	}
 
 	// TODO (che, 25.9 ) : Better way to achieve this
-	public def retrievePredecessorStatesForPatch(def patchNumber) {
+	public def retrieveRedoToState(def patchNumber) {
 		def id = patchNumber as Long
-		def patchStatus = sqlRetrievePatchStatus(id)
-		def relevantStatus = TargetSystemMappings.instance.relevantStateCode(patchStatus,fromToStates())
-		Assert.notNull(relevantStatus, "No relevant State found for ${patchNumber} with ${patchStatus}")
-		def precedessorStates = TargetSystemMappings.instance.findPredecessorStates(relevantStatus)
-		println precedessorStates.join("::")
-		precedessorStates
+		def patchCode = sqlRetrievePatchStatus(id)
+		def relevantToStateCode = TargetSystemMappings.instance.relevantStateCode(patchCode,fromToStates())
+		Assert.notNull(relevantToStateCode, "No relevant State found for ${patchNumber} with ${patchCode}")
+		def redoToState = TargetSystemMappings.instance.findState(relevantToStateCode)
+		redoToState
 	}
 
 

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbClient.groovy
@@ -45,13 +45,13 @@ class PatchDbClient {
 		listPatchFile.write(new JsonBuilder(patchlist:patchNumbers).toPrettyString())
 	}
 
-	// TODO (che, 25.9 ) : Better way to achieve this
 	public def retrieveRedoToState(def patchNumber) {
 		def id = patchNumber as Long
 		def patchCode = sqlRetrievePatchStatus(id)
 		def relevantToStateCode = TargetSystemMappings.instance.relevantStateCode(patchCode,fromToStates())
 		Assert.notNull(relevantToStateCode, "No relevant State found for ${patchNumber} with ${patchCode}")
 		def redoToState = TargetSystemMappings.instance.findState(relevantToStateCode)
+		println redoToState
 		redoToState
 	}
 

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/utils/TargetSystemMappings.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/utils/TargetSystemMappings.groovy
@@ -23,6 +23,17 @@ public class TargetSystemMappings {
 		statusNum
 	}
 	
+	def findState(stateCode) {
+		for (String key : targetSystemMappings.keySet()) {
+			def preState = targetSystemMappings[key]
+			if (stateCode.toString() == preState) {
+				return key
+			}
+		}
+		null
+	}
+
+	
 	def findPredecessorStates(state) {
 		def predecessorStates = []
 		for (String key : targetSystemMappings.keySet()) {

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/utils/TargetSystemMappings.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/utils/TargetSystemMappings.groovy
@@ -1,7 +1,5 @@
 package com.apgsga.patch.service.client.utils
 
-import com.google.common.cache.LocalCache.Values
-
 import groovy.json.JsonSlurper
 import groovy.transform.Synchronized
 

--- a/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/DbCliIntegrationTest.groovy
+++ b/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/DbCliIntegrationTest.groovy
@@ -60,8 +60,8 @@ class DbCliIntegrationTest extends Specification {
 		then:
 		result != null
 		result.returnCode == 0
-	 	result.result == ['Entwicklung', 'EntwicklungInstallationsbereit','InformatiktestInstallationsbereit','Informatiktest']
-		buffer.toString().trim().tokenize('::') == result.result
+	 	result.result == 'Informatiktest'
+		buffer.toString().trim() == result.result
 
 	}
 	


### PR DESCRIPTION
I changed to logic for redo support. 

Now, PatchDbCli returns to actual State which has to be redone, instead of the predessor States. See also Jenkins Patch Pipeline

@apgsga-jhe FYI, i am going ahead with merge and testing