### PR TITLE
Hide password for dev artifactory user

### DIFF
--- a/apg-patch-artifact-querymanager/src/main/java/com/apgsga/artifact/query/impl/RepositorySystemFactory.java
+++ b/apg-patch-artifact-querymanager/src/main/java/com/apgsga/artifact/query/impl/RepositorySystemFactory.java
@@ -17,11 +17,11 @@ import org.eclipse.aether.transport.file.FileTransporterFactory;
 import org.eclipse.aether.transport.http.HttpTransporterFactory;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 public class RepositorySystemFactory {
 	// TODO (che, 9.3 ) : Temporory fix
-	private static final String REPO_PASSWD = "dev1234";
 	private static final String REPO_USER = "dev";
 	private static final String HTTP_MAVENREPO_APGSGA_CH_NEXUS_CONTENT_GROUPS_PUBLIC = "https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga/repo";
 
@@ -63,7 +63,9 @@ public class RepositorySystemFactory {
 	}
 
 	private static RemoteRepository newCentralRepository(String name, String url) {
-        Authentication auth = new AuthenticationBuilder().addUsername(REPO_USER).addPassword( REPO_PASSWD ).build();
+		String repoPasswd = System.getenv("REPO_RO_PASSWD"); 
+		Preconditions.checkNotNull(repoPasswd,"Repo password should'nt be null");
+        Authentication auth = new AuthenticationBuilder().addUsername(REPO_USER).addPassword( repoPasswd ).build();
 		return new RemoteRepository.Builder(name, "default", url).setAuthentication( auth ).build();
 	}
 

--- a/apg-patch-service-client/src/main/java/com/apgsga/microservice/patch/client/MicroservicePatchClient.java
+++ b/apg-patch-service-client/src/main/java/com/apgsga/microservice/patch/client/MicroservicePatchClient.java
@@ -40,7 +40,7 @@ public class MicroservicePatchClient implements PatchService {
 
 	private static final String REMOVE = "/remove";
 
-	protected final Log LOGGER = LogFactory.getLog(getClass());
+	protected static Log LOGGER = LogFactory.getLog(MicroservicePatchClient.class.getName());
 
 	private String baseUrl;
 

--- a/apg-patch-service-cmdclient/build.gradle
+++ b/apg-patch-service-cmdclient/build.gradle
@@ -154,7 +154,7 @@ publishing {
 			url  "${mavenRepoBaseUrl}/${repoTarget}/"
 			credentials {
 				username = repoUser
-				password = repoPassword
+				password = System.env.REPO_RO_PASSWD
 			}
 		}
 	}
@@ -168,7 +168,7 @@ artifactory {
         repository {
             repoKey = 'yumrepodev'   
             username ="${repoUser}"
-            password = "${repoPassword}"
+            password = System.env.REPO_RO_PASSWD
             ivy {
                  artifactLayout = "${buildRpm.outputs.getFiles().getSingleFile().getName()}"
             }

--- a/apg-patch-service-cmdclient/packaging/profile/apscli.sh
+++ b/apg-patch-service-cmdclient/packaging/profile/apscli.sh
@@ -1,2 +1,3 @@
 # Have apscli in PATH 
 export PATH=$PATH:/opt/apg-patch-cli/bin
+export REPO_RO_PASSWD=entw1234

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchArtifactoryClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchArtifactoryClient.groovy
@@ -19,7 +19,9 @@ class PatchArtifactoryClient {
 	
 	def PatchArtifactoryClient(def configuration) {
 		config = configuration
-		artifactory = ArtifactoryClientBuilder.create().setUrl(config.artifactory.url).setUsername(config.artifactory.user).setPassword(config.artifactory.password).build();
+		def pass = System.getenv('REPO_RO_PASSWD')
+		assert pass != null
+		artifactory = ArtifactoryClientBuilder.create().setUrl(config.artifactory.url).setUsername(config.artifactory.user).setPassword(pass).build();
 	}
 	
 	public def removeArtifacts(String regex, boolean dryRun) {
@@ -48,17 +50,6 @@ class PatchArtifactoryClient {
 				// Will delete all published sources jar for the given version/revision
 				removeArtifacts("*-${it}-sources.jar", dryRun)
 			}
-					
-			// Cleaning Docker Image as well
-			// TODO JHE: Uncomment and adapt it as soon as JAVA8MIG-375 will be solved.
-			/*
-			if(!dryRun) {
-				def jadasCleanupCmd = "/opt/apgops/cleanup_jadas_images.sh ${originalFrom} ${lastRevision}"
-				println "Following command will be started to clean Jadas images : ${jadasCleanupCmd}"
-				['bash', '-c', jadasCleanupCmd].execute().getOutputStream().println()
-				println "Jadas Images have been deleted for ${target}"
-			}
-			*/
 		}			
 		else {
 			println("No release to clean for ${target}. We probably never have any patch installed directly on ${target}, or no patch has been newly installed since last clone.")

--- a/apg-patch-service-cmdclient/src/main/resources/apscli.properties
+++ b/apg-patch-service-cmdclient/src/main/resources/apscli.properties
@@ -9,7 +9,6 @@ environments {
         target.system.mapping.file.name = 'TargetSystemMappings.json'
         artifactory.url = 'https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga'
         artifactory.user = 'dev'
-        artifactory.password = 'dev1234'
         postclone.list.patch.file.path = 'src/test/resources/patchToBeReinstalled.json'
     }
     production {
@@ -22,7 +21,6 @@ environments {
         target.system.mapping.file.name = 'TargetSystemMappings.json'
         artifactory.url = 'https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga'
         artifactory.user = 'dev'
-        artifactory.password = 'dev1234'
         postclone.list.patch.file.path = '/var/opt/apg-patch-cli/patchToBeReinstalled.json'        
     }
 }

--- a/apg-patch-service-server/build.gradle
+++ b/apg-patch-service-server/build.gradle
@@ -182,7 +182,7 @@ artifactory {
         repository {
             repoKey = 'yumrepodev'   
             username ="${repoUser}"
-            password = "${repoPassword}"
+            password = System.env.REPO_RO_PASSWD
             ivy {
                  artifactLayout = "${buildRpm.outputs.getFiles().getSingleFile().getName()}"
             }

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ subprojects {
 		maven { 
 		  credentials {
             	username "$repoUser"
-            	password "$repoPassword"
+            	password System.env.REPO_RO_PASSWD
         	}
 			url "${mavenRepoBaseUrl}/repo" 
 		}
@@ -98,7 +98,7 @@ subprojects {
 				url  "${mavenRepoBaseUrl}/${repoTarget}/"				
 				credentials {
 					username = repoUser
-					password = repoPassword
+					password = System.env.REPO_RO_PASSWD
 				}
 			}
 		}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 mavenRepoBaseUrl=https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga
 org.gradle.caching=false
 repoUser=dev
-repoPassword=dev1234


### PR DESCRIPTION
The Artifactory Read-only User Password is available as Environment Variable: REPO_RO_PASSWD, instead of property value.  It is evaluated at Build time resp. Runtime . Developers need to add this Variable to their enviroments. 
In Jenkins it is configured as "Globale Eigentschaft", see https://jenkins.apgsga.ch/configure