### PR TITLE
Redo without db Query

### DIFF
--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbCli.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbCli.groovy
@@ -44,8 +44,6 @@ class PatchDbCli {
 			if(options.lpac) {
 				def status = options.lpacs[0]
 				cmdResults.result = dbCli.listPatchAfterClone(status,config.postclone.list.patch.file.path)
-			} else if (options.rsta) {
-				cmdResults.result  = dbCli.retrieveRedoToState(options.rsta)
 			} else if (options.sta) {
 				def patchNumber = options.stas[0]
 				def toState = options.stas[1]
@@ -93,7 +91,6 @@ class PatchDbCli {
 		cli.with {
 			h longOpt: 'help', 'Show usage information', required: false
 			lpac longOpt: 'listPatchAfterClone', args:1, argName: 'status', 'Get list of patches to be re-installed after a clone', required: false
-			rsta longOpt: 'retrievePatchStatus', args:1, argName: 'patchNumber', 'Get the Status for the Patch with PatchNumber', required: false
 			sta longOpt: 'stateChange', args:2, valueSeparator: ",", argName: 'patchNumber,toState', 'Notfiy State Change for a Patch with <patchNumber> to <toState> to the database', required: false
 		}
 
@@ -114,13 +111,6 @@ class PatchDbCli {
 		if(options.lpac) {
 			if(options.lpacs.size() != 1) {
 				println("Target status is required when fetching list of patch to be re-installed.")
-				error = true
-			}
-		}
-
-		if(options.rsta) {
-			if (!options.rsta.isInteger()) {
-				println "Patchnumber ${options.rsta} is not a Integer"
 				error = true
 			}
 		}

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbClient.groovy
@@ -45,33 +45,5 @@ class PatchDbClient {
 		listPatchFile.write(new JsonBuilder(patchlist:patchNumbers).toPrettyString())
 	}
 
-	public def retrieveRedoToState(def patchNumber) {
-		def id = patchNumber as Long
-		def patchCode = sqlRetrievePatchStatus(id)
-		def relevantToStateCode = TargetSystemMappings.instance.relevantStateCode(patchCode,fromToStates())
-		Assert.notNull(relevantToStateCode, "No relevant State found for ${patchNumber} with ${patchCode}")
-		def redoToState = TargetSystemMappings.instance.findState(relevantToStateCode)
-		println redoToState
-		redoToState
-	}
-
-
-	private def sqlRetrievePatchStatus(def id) {
-		def sql = 'select status from  cm_patch_f where id = :patchNumber';
-		def row = dbConnection.firstRow(sql, [patchNumber:id])
-		Assert.notNull(row,"Patch with Id: ${id} not found")
-		Assert.notNull(row.STATUS,"Unexpected Column for sql: ${sql}")
-		def patchStatus =  row.STATUS
-		patchStatus
-	}
-	
-	// TODO (che , 20.9 ) Would be nice, but the required predecessor state are not complete
-	private def fromToStates() {
-		def sql = 'select von_status fromState, zu_status toState from cm_patch_berechtigung_f where user_id in (select user from dual)';
-		def allowedStateChanges = dbConnection.rows(sql)
-		Assert.isTrue(!allowedStateChanges.empty, "Unexpected result")
-		allowedStateChanges
-	}
-
 
 }

--- a/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/DbCliIntegrationTest.groovy
+++ b/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/DbCliIntegrationTest.groovy
@@ -43,42 +43,7 @@ class DbCliIntegrationTest extends Specification {
 		cleanup:
 		outputFile.delete()
 	}
-
-
-	@Requires({patchExists("22222")})
-	def "Patch DB Cli  returns predecessor States of Patch"() {
-		setup:
-		def patchDbCli = PatchDbCli.create()
-		def result
-		def savedOut
-		def buffer
-		when:
-		savedOut = System.out;
-		buffer = new ByteArrayOutputStream()
-		System.setOut(new PrintStream(buffer))
-		result = patchDbCli.process(["-rsta", "5792"])
-		System.setOut(savedOut)
-		then:
-		result != null
-		result.returnCode == 0
-	 	result.result == 'ProduktionInstallationsbereit'
-		buffer.toString().trim() == result.result
-
-	}
 	
-	@Requires({dbAvailable()})
-	def "Patch DB Cli tries to retrieve predecessor States non existing Patch"() {
-		setup:
-		def patchDbCli = PatchDbCli.create()
-		def result
-		when:
-		result = patchDbCli.process(["-rsta", "99999"])
-		then:
-		result != null
-		result.returnCode == 1
-		result.error.getClass().getName() == "java.lang.IllegalArgumentException"
-		result.error.message == "Patch with Id: 99999 not found"
-	}
 	
 	@Requires({patchExists("5799")})
 	def "Patch DB Cli  update status of Patch"() {

--- a/apg-patch-service-common/src/main/java/com/apgsga/microservice/patch/api/Patch.java
+++ b/apg-patch-service-common/src/main/java/com/apgsga/microservice/patch/api/Patch.java
@@ -105,6 +105,10 @@ public interface Patch extends ServiceMetaData {
 
 	public void setRunningNr(String runningNr);
 	
+	public String getTargetToState(); 
+	
+	public void setTargetToState(String targetToState);
+	
 	public boolean getInstallOnEmptyModules();
 	
 	public void setInstallOnEmptyModules(boolean installOnEmptyModules);

--- a/apg-patch-service-common/src/main/java/com/apgsga/microservice/patch/api/impl/PatchBean.java
+++ b/apg-patch-service-common/src/main/java/com/apgsga/microservice/patch/api/impl/PatchBean.java
@@ -23,6 +23,7 @@ public class PatchBean extends AbstractTransientEntity implements Patch {
 	private String patchTag = "";
 	private Integer tagNr = 0;
 	private String installationTarget;
+	private String targetToState;
 	private String baseVersionNumber;
 	private String revisionMnemoPart;
 	private String revision;
@@ -290,6 +291,15 @@ public class PatchBean extends AbstractTransientEntity implements Patch {
 	}
 	
 	
+	@Override
+	public String getTargetToState() {
+		return targetToState;
+	}
+
+	@Override
+	public void setTargetToState(String targetToState) {
+		this.targetToState = targetToState;
+	}
 
 	@Override
 	public int hashCode() {
@@ -311,6 +321,7 @@ public class PatchBean extends AbstractTransientEntity implements Patch {
 		result = prime * result + ((runningNr == null) ? 0 : runningNr.hashCode());
 		result = prime * result + ((serviceName == null) ? 0 : serviceName.hashCode());
 		result = prime * result + ((tagNr == null) ? 0 : tagNr.hashCode());
+		result = prime * result + ((targetToState == null) ? 0 : targetToState.hashCode());
 		return result;
 	}
 
@@ -400,6 +411,11 @@ public class PatchBean extends AbstractTransientEntity implements Patch {
 				return false;
 		} else if (!tagNr.equals(other.tagNr))
 			return false;
+		if (targetToState == null) {
+			if (other.targetToState != null)
+				return false;
+		} else if (!targetToState.equals(other.targetToState))
+			return false;
 		return true;
 	}
 
@@ -407,11 +423,13 @@ public class PatchBean extends AbstractTransientEntity implements Patch {
 	public String toString() {
 		return "PatchBean [patchNummer=" + patchNummer + ", serviceName=" + serviceName + ", microServiceBranch="
 				+ microServiceBranch + ", dbPatchBranch=" + dbPatchBranch + ", prodBranch=" + prodBranch + ", patchTag="
-				+ patchTag + ", tagNr=" + tagNr + ", installationTarget=" + installationTarget + ", baseVersionNumber="
-				+ baseVersionNumber + ", revisionMnemoPart=" + revisionMnemoPart + ", revision=" + revision
-				+ ", lastRevision=" + lastRevision + ", runningNr=" + runningNr + ", dbObjects=" + dbObjects
-				+ ", mavenArtifacts=" + mavenArtifacts + ", installOnEmptyModules=" + installOnEmptyModules + "]";
+				+ patchTag + ", tagNr=" + tagNr + ", installationTarget=" + installationTarget + ", targetToState="
+				+ targetToState + ", baseVersionNumber=" + baseVersionNumber + ", revisionMnemoPart="
+				+ revisionMnemoPart + ", revision=" + revision + ", lastRevision=" + lastRevision + ", runningNr="
+				+ runningNr + ", dbObjects=" + dbObjects + ", mavenArtifacts=" + mavenArtifacts
+				+ ", installOnEmptyModules=" + installOnEmptyModules + "]";
 	}
 
+	
 
 }


### PR DESCRIPTION
The restart mechanism of the Patch Pipeline now saves the state of PatchConfig into Patch*.json file of the a Patch newly also before the execution of a Stage. In case of a failure of the Pipeline the target redo State is taken from PatchConfig: targetToState.
This makes any db query for the state and targetToState of a Patch unnecessary. Respective code has been eliminated. 
Also the necessary attribute targetToState has been added to Patch