### PR TITLE
Java8mig583 clean rpm patch

### DIFF
--- a/apg-patch-service-cmdclient/packaging/conf/application.properties
+++ b/apg-patch-service-cmdclient/packaging/conf/application.properties
@@ -8,3 +8,4 @@ artifactory.user=dev
 postclone.list.patch.file.path=/var/opt/apg-patch-cli/patchToBeReinstalled.json
 artifactory.dbpatch.repo.name=dbpatch
 artifactory.release.repo.name=releases
+artifactory.patch.repo.name=yumpatchrepo

--- a/apg-patch-service-cmdclient/packaging/conf/application.properties
+++ b/apg-patch-service-cmdclient/packaging/conf/application.properties
@@ -8,4 +8,4 @@ artifactory.user=dev
 postclone.list.patch.file.path=/var/opt/apg-patch-cli/patchToBeReinstalled.json
 artifactory.dbpatch.repo.name=dbpatch
 artifactory.release.repo.name=releases
-artifactory.patch.repo.name=yumpatchrepo
+artifactory.patch.rpm.repo.name=yumpatchrepo

--- a/apg-patch-service-cmdclient/src/test/resources/config/app-test.properties
+++ b/apg-patch-service-cmdclient/src/test/resources/config/app-test.properties
@@ -6,6 +6,7 @@ target.system.mapping.file.name=TargetSystemMappings.json
 postclone.list.patch.file.path=src/test/resources/patchToBeReinstalled.json
 artifactory.dbpatch.repo.name=dbpatch
 artifactory.release.repo.name=releases
+artifactory.patch.rpm.repo.name=yumpatchrepo
 mavenrepo.user.name=dev
 mavenrepo.baseurl=https://artifactory4t4apgsga.jfrog.io/artifactory4t4apgsga
 mavenrepo.name=repo


### PR DESCRIPTION
We don't need to call the "/opt/apgops/cleanup_jadas_images_by_revision.sh" OPS script anymore. In theory, we will be able to delete the RPMs just like we do for other resources in other repositories.

@chhex : I'll quickly merge this one, this serves more as for FYI .... If then something doesn't work during my tests, I'll fix directly on master.