### PR TITLE
Avoid multiple prod patch pipeline to run in parallel when restarting a pipeline

### DIFF
--- a/apg-patch-service-common/src/main/java/com/apgsga/microservice/patch/exceptions/Asserts.java
+++ b/apg-patch-service-common/src/main/java/com/apgsga/microservice/patch/exceptions/Asserts.java
@@ -18,6 +18,12 @@ public class Asserts {
 			throw ExceptionFactory.createPatchServiceRuntimeException(key, variables);
 		}
 	}
+	
+	public static void isFalse(Boolean expression, String key, Object[] variables) {
+		if (expression) {
+			throw ExceptionFactory.createPatchServiceRuntimeException(key, variables);
+		}
+	}
 
 	public static void notNullOrEmpty(String string, String key, Object[] variables) {
 		if (Strings.isNullOrEmpty(string == null ? null : string.trim())) {

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/SimplePatchContainerBean.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/SimplePatchContainerBean.java
@@ -255,7 +255,7 @@ public class SimplePatchContainerBean implements PatchService, PatchOpService {
 				new Object[] {});
 		Asserts.isTrue((repo.patchExists(patchNumber)),
 				"SimplePatchContainerBean.restartProdPipeline.patch.exists.assert", new Object[] { patchNumber });
-		Asserts.isFalse(jenkinsClient.isProdPipelineForPatchRunning(patchNumber), "SimplePatchContainerBean.restartProdPipeline.patch.alreadyRunning", new Object[]{patchNumber});
+		Asserts.isFalse(jenkinsClient.isProdPatchPipelineRunning(patchNumber), "SimplePatchContainerBean.restartProdPipeline.patch.alreadyRunning", new Object[]{patchNumber});
 		Patch patch = repo.findById(patchNumber);
 		jenkinsClient.restartProdPatchPipeline(patch);
 	}

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/SimplePatchContainerBean.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/SimplePatchContainerBean.java
@@ -255,10 +255,11 @@ public class SimplePatchContainerBean implements PatchService, PatchOpService {
 				new Object[] {});
 		Asserts.isTrue((repo.patchExists(patchNumber)),
 				"SimplePatchContainerBean.restartProdPipeline.patch.exists.assert", new Object[] { patchNumber });
+		Asserts.isFalse(jenkinsClient.isProdPipelineForPatchRunning(patchNumber), "SimplePatchContainerBean.restartProdPipeline.patch.alreadyRunning", new Object[]{patchNumber});
 		Patch patch = repo.findById(patchNumber);
 		jenkinsClient.restartProdPatchPipeline(patch);
 	}
-
+	
 	private List<MavenArtifact> getArtifactNameError(List<MavenArtifact> mavenArtifacts, String cvsBranch) {
 
 		VcsCommandRunner cmdRunner = getJschSessionFactory().create();

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/SimplePatchContainerBean.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/SimplePatchContainerBean.java
@@ -256,6 +256,7 @@ public class SimplePatchContainerBean implements PatchService, PatchOpService {
 		Asserts.isTrue((repo.patchExists(patchNumber)),
 				"SimplePatchContainerBean.restartProdPipeline.patch.exists.assert", new Object[] { patchNumber });
 		Asserts.isFalse(jenkinsClient.isProdPatchPipelineRunning(patchNumber), "SimplePatchContainerBean.restartProdPipeline.patch.alreadyRunning", new Object[]{patchNumber});
+		Asserts.isTrue(jenkinsClient.isLastProdPipelineBuildInError(patchNumber), "SimplePatchContainerBean.restartProdPipeline.patch.lastBuildInError", new Object[]{patchNumber});
 		Patch patch = repo.findById(patchNumber);
 		jenkinsClient.restartProdPatchPipeline(patch);
 	}

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClient.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClient.java
@@ -21,5 +21,6 @@ public interface JenkinsClient {
 	
 	public void onClone(String source, String target);
 	
-	public boolean isProdPipelineForPatchRunning(String patchNumber);
+	public boolean isProdPatchPipelineRunning(String patchNumber);
+	
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClient.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClient.java
@@ -23,4 +23,5 @@ public interface JenkinsClient {
 	
 	public boolean isProdPatchPipelineRunning(String patchNumber);
 	
+	public boolean isLastProdPipelineBuildInError(String patchNumber);
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClient.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClient.java
@@ -20,5 +20,6 @@ public interface JenkinsClient {
 	public void processInputAction(Patch patch, String target, String stage);
 	
 	public void onClone(String source, String target);
-
+	
+	public boolean isProdPipelineForPatchRunning(String patchNumber);
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClientImpl.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClientImpl.java
@@ -294,9 +294,21 @@ public class JenkinsClientImpl implements JenkinsClient {
 		try {
 			jenkinsServer = new JenkinsServer(new URI(jenkinsUrl), jenkinsUser, jenkinsUserAuthKey);
 			PipelineBuild lastBuild = getPipelineBuild(jenkinsServer, patchNumber);
-			return lastBuild.getWorkflowRun().isInProgress();
+			return lastBuild.details().isBuilding();
 		} catch (Exception e) {
 			throw ExceptionFactory.createPatchServiceRuntimeException("JenkinsPatchClientImpl.isProdPipelineForPatchRunning.error", new Object[]{patchNumber});
+		}
+	}
+
+	@Override
+	public boolean isLastProdPipelineBuildInError(String patchNumber) {
+		JenkinsServer jenkinsServer;
+		try {
+			jenkinsServer = new JenkinsServer(new URI(jenkinsUrl), jenkinsUser, jenkinsUserAuthKey);
+			PipelineBuild lastBuild = getPipelineBuild(jenkinsServer, patchNumber);
+			return lastBuild.details().getResult().equals(BuildResult.FAILURE);
+		} catch (Exception e) {
+			throw ExceptionFactory.createPatchServiceRuntimeException("JenkinsPatchClientImpl.isLastProdPipelineBuildInError.error", new Object[]{patchNumber});
 		}
 	}
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClientImpl.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClientImpl.java
@@ -289,7 +289,7 @@ public class JenkinsClientImpl implements JenkinsClient {
 	}
 
 	@Override
-	public boolean isProdPipelineForPatchRunning(String patchNumber) {
+	public boolean isProdPatchPipelineRunning(String patchNumber) {
 		JenkinsServer jenkinsServer;
 		try {
 			jenkinsServer = new JenkinsServer(new URI(jenkinsUrl), jenkinsUser, jenkinsUserAuthKey);

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClientImpl.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClientImpl.java
@@ -3,6 +3,7 @@ package com.apgsga.microservice.patch.server.impl.jenkins;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 
@@ -287,4 +288,15 @@ public class JenkinsClientImpl implements JenkinsClient {
 				"JenkinsPatchClientImpl.triggerPipelineJobAndWaitUntilBuilding.error", new Object[] { jobName });
 	}
 
+	@Override
+	public boolean isProdPipelineForPatchRunning(String patchNumber) {
+		JenkinsServer jenkinsServer;
+		try {
+			jenkinsServer = new JenkinsServer(new URI(jenkinsUrl), jenkinsUser, jenkinsUserAuthKey);
+			PipelineBuild lastBuild = getPipelineBuild(jenkinsServer, patchNumber);
+			return lastBuild.getWorkflowRun().isInProgress();
+		} catch (Exception e) {
+			throw ExceptionFactory.createPatchServiceRuntimeException("JenkinsPatchClientImpl.isProdPipelineForPatchRunning.error", new Object[]{patchNumber});
+		}
+	}
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsMockClient.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsMockClient.java
@@ -60,7 +60,7 @@ public class JenkinsMockClient implements JenkinsClient {
 	}
 
 	@Override
-	public boolean isProdPipelineForPatchRunning(String patchNumber) {
+	public boolean isProdPatchPipelineRunning(String patchNumber) {
 		LOGGER.info("isProdPipelineForPatchRunning for :" + patchNumber);
 		return false;
 	}	

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsMockClient.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsMockClient.java
@@ -61,7 +61,13 @@ public class JenkinsMockClient implements JenkinsClient {
 
 	@Override
 	public boolean isProdPatchPipelineRunning(String patchNumber) {
-		LOGGER.info("isProdPipelineForPatchRunning for :" + patchNumber);
+		LOGGER.info("isProdPatchPipelineRunning for :" + patchNumber);
+		return false;
+	}
+
+	@Override
+	public boolean isLastProdPipelineBuildInError(String patchNumber) {
+		LOGGER.info("isLastProdPipelineBuildInError for : " + patchNumber);
 		return false;
 	}	
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsMockClient.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsMockClient.java
@@ -57,6 +57,11 @@ public class JenkinsMockClient implements JenkinsClient {
 	@Override
 	public void onClone(String source, String target) {
 		LOGGER.info("onClone for source=" + source + " , target=" + target);		
-	}	
+	}
 
+	@Override
+	public boolean isProdPipelineForPatchRunning(String patchNumber) {
+		LOGGER.info("isProdPipelineForPatchRunning for :" + patchNumber);
+		return false;
+	}	
 }

--- a/apg-patch-service-server/src/main/resources/messages.properties
+++ b/apg-patch-service-server/src/main/resources/messages.properties
@@ -14,7 +14,8 @@ SimplePatchContainerBean.startInstallPipeline.patchnumber.notnull.assert=Patch n
 SimplePatchContainerBean.startInstallPipeline.patch.exists.assert=Patch: {0} to startInstallPipeline not found 
 SimplePatchContainerBean.restartProdPipeline.patchnumber.notnull.assert=Patchnumber null for restartProdPipeline
 SimplePatchContainerBean.restartProdPipeline.patch.exists.assert=Patch with Patchnumber: {0} to restartProdPipeline not found
-SimplePatchContainerBean.restartProdPipeline.patch.alreadyRunning=Patch {0} can't be restarted as he's already running 
+SimplePatchContainerBean.restartProdPipeline.patch.alreadyRunning=Patch {0} can't be restarted as he's already running
+SimplePatchContainerBean.restartProdPipeline.patch.lastBuildInError=Patch {0} can't be restarted as the last build didn't end with an error 
 EntwicklungInstallationsbereitAction.patch.exists.assert=Patch with number: {0} for toState Action {1} not found 
 PipelineInputAction.patch.exists.assert=Patch with number: {0} for toState Action {1} not found 
 GroovyScriptActionExecutor.execute.exception=Exception: <{0}> while Executing Groovy Action script:  {1} failed for Patch : {2} , toStatus: {3} , configDir: {4} and File: {5}
@@ -51,5 +52,6 @@ Groovy.script.executePatchAction.configfile.exists.assert=Config File {0} does n
 Groovy.script.executePatchAction.state.exits.assert=Invalid to state: {0} for Patch: {1}
 JenkinsAdminClientImpl.startPipeline.error=Starting onClone pipeline failed for target {0}
 JenkinsPatchClientImpl.isProdPipelineForPatchRunning.error=Couldn't determine if patch {0} is already running
+JenkinsPatchClientImpl.isLastProdPipelineBuildInError.error=Couldn't determine if last prod pipeline for patch {0} ended with an error
 
 

--- a/apg-patch-service-server/src/main/resources/messages.properties
+++ b/apg-patch-service-server/src/main/resources/messages.properties
@@ -13,7 +13,8 @@ SimplePatchContainerBean.startInstallPipeline.patchobject.notnull.assert=Patch o
 SimplePatchContainerBean.startInstallPipeline.patchnumber.notnull.assert=Patch number null for startInstallPipeline of Patch : {0}
 SimplePatchContainerBean.startInstallPipeline.patch.exists.assert=Patch: {0} to startInstallPipeline not found 
 SimplePatchContainerBean.restartProdPipeline.patchnumber.notnull.assert=Patchnumber null for restartProdPipeline
-SimplePatchContainerBean.restartProdPipeline.patch.exists.assert=Patch with Patchnumber: {0} to restartProdPipeline not found 
+SimplePatchContainerBean.restartProdPipeline.patch.exists.assert=Patch with Patchnumber: {0} to restartProdPipeline not found
+SimplePatchContainerBean.restartProdPipeline.patch.alreadyRunning=Patch {0} can't be restarted as he's already running 
 EntwicklungInstallationsbereitAction.patch.exists.assert=Patch with number: {0} for toState Action {1} not found 
 PipelineInputAction.patch.exists.assert=Patch with number: {0} for toState Action {1} not found 
 GroovyScriptActionExecutor.execute.exception=Exception: <{0}> while Executing Groovy Action script:  {1} failed for Patch : {2} , toStatus: {3} , configDir: {4} and File: {5}
@@ -49,5 +50,6 @@ Groovy.script.executePatchAction.configdir.exists.assert=Config Dir {0} does not
 Groovy.script.executePatchAction.configfile.exists.assert=Config File {0} does not exist for Patch: {2} and to {0}
 Groovy.script.executePatchAction.state.exits.assert=Invalid to state: {0} for Patch: {1}
 JenkinsAdminClientImpl.startPipeline.error=Starting onClone pipeline failed for target {0}
+JenkinsPatchClientImpl.isProdPipelineForPatchRunning.error=Couldn't determine if patch {0} is already running
 
 


### PR DESCRIPTION
Changes for java8mig-725.
I still need to test on jenkins-t, but could you already have a look, and eventually provide me a feedback?
One remark concerning com.apgsga.microservice.patch.server.impl.jenkins.JenkinsClientImpl.isLastProdPipelineBuildInError(String) method: BuildResult contains couple of other status apart from FAILURE. But in that case, we're (I believe) only interested by the FAILURE state. I mean, I don't believe we should use the "redo" if a patch was for example explicitely aborted ... in that case, standard patch workflow should be done again.