### PR TITLE
JAVA8MIG-680 - Not waiting on feedback when submitting onDemand Job.

### DIFF
--- a/apg-patch-service-server/src/main/resources/messages.properties
+++ b/apg-patch-service-server/src/main/resources/messages.properties
@@ -41,6 +41,7 @@ JenkinsPatchClientImpl.createPatchPipelines.exception=Exception: <{0}> while sta
 JenkinsPatchClientImpl.inputActionForPipeline.error=Jenkins Input Action : {1} for Patch Pipeline Job for Patch: {0} not found
 JenkinsPatchClientImpl.processInputAction.exception=Exception: <{0}> while processing Jenkins Input Action for Patch:  {1}
 JenkinsPatchClientImpl.triggerPipelineJobAndWaitUntilBuilding.error="Could'nt Trigger Job: {0} and wait until Building"
+JenkinsPatchClientImpl.triggerPipelineJobWithoutWaitingOnFeedback.exception=Exception: <{0}> while trying to start following Job: {1}
 InstallTargetsUtil.listInstallTargets.exception=Exception: <{0}> while listing Installation Targets from File:  {1} 
 GroovyScriptActionExecutor.execute.scriptfileexists.assert=Groovy Script File {0} does not existts. Patch: {1} and toAction: {2}
 GroovyScriptActionExecutor.execute.patchnumber.notnullorempty.assert=Patch number null for empty for Script Execution toAction: {0}

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ project.ext {
 allprojects  {
 	apply plugin: 'maven'
 	group = 'com.apgsga.patchframework'
-	version  = '1.3.7'
+	version  = '1.3.11'
 }
 subprojects {
 	apply plugin: 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ project.ext {
 allprojects  {
 	apply plugin: 'maven'
 	group = 'com.apgsga.patchframework'
-	version  = '1.3.11'
+	version  = '1.3.9'
 }
 subprojects {
 	apply plugin: 'java'


### PR DESCRIPTION
I still need to test on Jenkins-t, but as for the other Pull Request, early feedback are welcome.

Basically nothing complicated, instead of looping and waiting on the job to start, simply submit and return. Probably the "triggerPipelineJobWithoutWaitingOnFeedback" doesn't necessarily needs to be synchronized, but it also won't hurt.