### PR TITLE
separated onclone pipeline for each target

### DIFF
--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchServiceClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchServiceClient.groovy
@@ -148,7 +148,7 @@ class PatchServiceClient implements PatchOpService, PatchPersistence {
 
 	@Override
 	public void onClone(String source, String target) {
-		restTemplate.postForLocation(getRestBaseUri() + "/onClone?source=${source}&target=${target}", null)
+		restTemplate.postForLocation(getRestBaseUri() + "/onClone${target.toUpperCase()}?source=${source}&target=${target}", null)
 	}
 
 	class PatchServiceErrorHandler implements ResponseErrorHandler {

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/db/PatchDbClient.groovy
@@ -26,12 +26,19 @@ class PatchDbClient {
 	public def listPatchAfterClone(def status, def filePath) {
 		def String sql = "SELECT id FROM cm_patch_install_sequence_f WHERE ${status}=1 AND (produktion = 0 OR chronology > trunc(SYSDATE))"
 		def patchNumbers = []
-		dbConnection.eachRow(sql) { row ->
-			def rowId = row.ID
-			println "Patch ${rowId} added to the list of patch to be re-installed."
-			patchNumbers.add(rowId)
-		}
+		try {
+			dbConnection.eachRow(sql) { row ->
+				def rowId = row.ID
+				patchNumbers.add(rowId)
+			}
 
+		}
+		catch(Exception ex) {
+			// TODO JHE(11.04.2019): because the caller will read the stdout in order to determine if all went well ... we can't write the error message. But we need to find a way to log the exception.
+			println false
+			return
+		}
+		
 		// TODO (jhe, che, 19.9) have filePath passed as parameter and not preconfigured
 		// Or write it stdout , but without any other println
 		def listPatchFile = new File(filePath)
@@ -39,9 +46,8 @@ class PatchDbClient {
 		if(listPatchFile.exists()) {
 			listPatchFile.delete()
 		}
-
+		
 		listPatchFile.write(new JsonBuilder(patchlist:patchNumbers).toPrettyString())
+		println true
 	}
-
-
 }

--- a/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/PatchCliIntegrationTest.groovy
+++ b/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/PatchCliIntegrationTest.groovy
@@ -121,8 +121,6 @@ public class PatchCliIntegrationTest extends Specification {
 		repo.clean()
 	}
 	
-	// JHE (11.04.2019) : Deactivate for now, needs to be adapted based on changes made for JAVA8MIG-725
-	@Ignore
 	def "Patch Cli redo's Patch, which has been saved before with -sa"() {
 		setup:
 		def client = PatchCli.create()

--- a/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/PatchCliIntegrationTest.groovy
+++ b/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/PatchCliIntegrationTest.groovy
@@ -1,17 +1,13 @@
 package com.apgsga.patch.service.client;
 
-import org.junit.Rule
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.context.annotation.PropertySource
-import org.springframework.context.annotation.Configuration
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestPropertySource;
 
 import com.apgsga.microservice.patch.api.DbModules
@@ -19,10 +15,8 @@ import com.apgsga.microservice.patch.api.Patch
 import com.apgsga.microservice.patch.api.PatchPersistence
 import com.apgsga.microservice.patch.api.ServicesMetaData
 import com.apgsga.microservice.patch.server.MicroPatchServer;
-import com.apgsga.patch.service.client.revision.PatchRevisionCli
 import com.fasterxml.jackson.databind.ObjectMapper
-import groovy.json.JsonBuilder
-import groovy.json.JsonSlurper
+
 import spock.lang.Ignore
 import spock.lang.Specification;
 
@@ -127,6 +121,8 @@ public class PatchCliIntegrationTest extends Specification {
 		repo.clean()
 	}
 	
+	// JHE (11.04.2019) : Deactivate for now, needs to be adapted based on changes made for JAVA8MIG-725
+	@Ignore
 	def "Patch Cli redo's Patch, which has been saved before with -sa"() {
 		setup:
 		def client = PatchCli.create()

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsMockClient.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsMockClient.java
@@ -68,6 +68,6 @@ public class JenkinsMockClient implements JenkinsClient {
 	@Override
 	public boolean isLastProdPipelineBuildInError(String patchNumber) {
 		LOGGER.info("isLastProdPipelineBuildInError for : " + patchNumber);
-		return false;
+		return true;
 	}	
 }


### PR DESCRIPTION
Not sure the pull request name is 100% right ... is it really related with JAVA8MIG-730 ... but ok, detail...

- Calling onClone pipeline with target specific name
- Catching exception when fetching list of patches to be reinstalled and printing "true"/"false" on stdout in order for the caller to catch the result.
(- Ignoring one test as it still needs to be adapted for JAVA8MIG-725...)

