### PR TITLE
java8mig-747 / Preconditions to allow redo of aborted Pipelines

### DIFF
--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/SimplePatchContainerBean.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/SimplePatchContainerBean.java
@@ -42,6 +42,7 @@ import com.apgsga.microservice.patch.server.impl.vcs.VcsCommandRunner;
 import com.apgsga.microservice.patch.server.impl.vcs.VcsCommandRunnerFactory;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.offbytwo.jenkins.model.BuildResult;
 
 @Component("ServerBean")
 public class SimplePatchContainerBean implements PatchService, PatchOpService {
@@ -277,7 +278,8 @@ public class SimplePatchContainerBean implements PatchService, PatchOpService {
 	}
 	
 	private boolean isLastProdPipelineAbortedOrInError(String patchNumber) {
-		return jenkinsClient.isLastProdPipelineBuildInError(patchNumber) || jenkinsClient.isLastProdPipelineBuildAborted(patchNumber);
+		BuildResult result = jenkinsClient.getProdPipelineBuildResult(patchNumber);
+		return result.equals(BuildResult.ABORTED) || result.equals(BuildResult.FAILURE);
 	}
 	
 	private List<MavenArtifact> getArtifactNameError(List<MavenArtifact> mavenArtifacts, String cvsBranch) {

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/SimplePatchContainerBean.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/SimplePatchContainerBean.java
@@ -271,9 +271,13 @@ public class SimplePatchContainerBean implements PatchService, PatchOpService {
 		Asserts.isTrue((repo.patchExists(patchNumber)),
 				"SimplePatchContainerBean.restartProdPipeline.patch.exists.assert", new Object[] { patchNumber });
 		Asserts.isFalse(jenkinsClient.isProdPatchPipelineRunning(patchNumber), "SimplePatchContainerBean.restartProdPipeline.patch.alreadyRunning", new Object[]{patchNumber});
-		Asserts.isTrue(jenkinsClient.isLastProdPipelineBuildInError(patchNumber), "SimplePatchContainerBean.restartProdPipeline.patch.lastBuildInError", new Object[]{patchNumber});
+		Asserts.isTrue(isLastProdPipelineAbortedOrInError(patchNumber), "SimplePatchContainerBean.restartProdPipeline.patch.lastBuildInErrorOrAborted", new Object[]{patchNumber});
 		Patch patch = repo.findById(patchNumber);
 		jenkinsClient.restartProdPatchPipeline(patch);
+	}
+	
+	private boolean isLastProdPipelineAbortedOrInError(String patchNumber) {
+		return jenkinsClient.isLastProdPipelineBuildInError(patchNumber) || jenkinsClient.isLastProdPipelineBuildAborted(patchNumber);
 	}
 	
 	private List<MavenArtifact> getArtifactNameError(List<MavenArtifact> mavenArtifacts, String cvsBranch) {

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClient.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClient.java
@@ -3,6 +3,7 @@ package com.apgsga.microservice.patch.server.impl.jenkins;
 import java.util.Map;
 
 import com.apgsga.microservice.patch.api.Patch;
+import com.offbytwo.jenkins.model.BuildResult;
 
 public interface JenkinsClient {
 	public void createPatchPipelines(Patch patch);
@@ -23,7 +24,5 @@ public interface JenkinsClient {
 	
 	public boolean isProdPatchPipelineRunning(String patchNumber);
 	
-	public boolean isLastProdPipelineBuildInError(String patchNumber);
-	
-	public boolean isLastProdPipelineBuildAborted(String patchNumber);
+	public BuildResult getProdPipelineBuildResult(String patchNumber);
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClient.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClient.java
@@ -24,4 +24,6 @@ public interface JenkinsClient {
 	public boolean isProdPatchPipelineRunning(String patchNumber);
 	
 	public boolean isLastProdPipelineBuildInError(String patchNumber);
+	
+	public boolean isLastProdPipelineBuildAborted(String patchNumber);
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClientImpl.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClientImpl.java
@@ -315,23 +315,14 @@ public class JenkinsClientImpl implements JenkinsClient {
 	}
 
 	@Override
-	public boolean isLastProdPipelineBuildInError(String patchNumber) {
-		return matchLastProdPipelineBuildResult(patchNumber, BuildResult.FAILURE);
-	}
-
-	@Override
-	public boolean isLastProdPipelineBuildAborted(String patchNumber) {
-		return matchLastProdPipelineBuildResult(patchNumber, BuildResult.ABORTED);
-	}
-	
-	private boolean matchLastProdPipelineBuildResult(String patchNumber, BuildResult expectedBuildResult) {
+	public BuildResult getProdPipelineBuildResult(String patchNumber) {
 		JenkinsServer jenkinsServer;
 		try {
 			jenkinsServer = new JenkinsServer(new URI(jenkinsUrl), jenkinsUser, jenkinsUserAuthKey);
 			PipelineBuild lastBuild = getPipelineBuild(jenkinsServer, patchNumber);
-			return lastBuild.details().getResult().equals(expectedBuildResult);
+			return lastBuild.details().getResult();
 		} catch (Exception e) {
-			throw ExceptionFactory.createPatchServiceRuntimeException("JenkinsPatchClientImpl.matchLastProdPipelineBuildResult.error", new Object[]{patchNumber});
+			throw ExceptionFactory.createPatchServiceRuntimeException("JenkinsPatchClientImpl.getProdPipelineBuildResult.error", new Object[]{patchNumber});
 		}
 	}
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClientImpl.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsClientImpl.java
@@ -316,13 +316,22 @@ public class JenkinsClientImpl implements JenkinsClient {
 
 	@Override
 	public boolean isLastProdPipelineBuildInError(String patchNumber) {
+		return matchLastProdPipelineBuildResult(patchNumber, BuildResult.FAILURE);
+	}
+
+	@Override
+	public boolean isLastProdPipelineBuildAborted(String patchNumber) {
+		return matchLastProdPipelineBuildResult(patchNumber, BuildResult.ABORTED);
+	}
+	
+	private boolean matchLastProdPipelineBuildResult(String patchNumber, BuildResult expectedBuildResult) {
 		JenkinsServer jenkinsServer;
 		try {
 			jenkinsServer = new JenkinsServer(new URI(jenkinsUrl), jenkinsUser, jenkinsUserAuthKey);
 			PipelineBuild lastBuild = getPipelineBuild(jenkinsServer, patchNumber);
-			return lastBuild.details().getResult().equals(BuildResult.FAILURE);
+			return lastBuild.details().getResult().equals(expectedBuildResult);
 		} catch (Exception e) {
-			throw ExceptionFactory.createPatchServiceRuntimeException("JenkinsPatchClientImpl.isLastProdPipelineBuildInError.error", new Object[]{patchNumber});
+			throw ExceptionFactory.createPatchServiceRuntimeException("JenkinsPatchClientImpl.matchLastProdPipelineBuildResult.error", new Object[]{patchNumber});
 		}
 	}
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsMockClient.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsMockClient.java
@@ -69,5 +69,11 @@ public class JenkinsMockClient implements JenkinsClient {
 	public boolean isLastProdPipelineBuildInError(String patchNumber) {
 		LOGGER.info("isLastProdPipelineBuildInError for : " + patchNumber);
 		return true;
+	}
+
+	@Override
+	public boolean isLastProdPipelineBuildAborted(String patchNumber) {
+		LOGGER.info("isLastProdPipelineBuildAborted : " + patchNumber);
+		return true;
 	}	
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsMockClient.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/jenkins/JenkinsMockClient.java
@@ -6,6 +6,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.apgsga.microservice.patch.api.Patch;
+import com.offbytwo.jenkins.model.BuildResult;
 
 public class JenkinsMockClient implements JenkinsClient {
 
@@ -66,14 +67,8 @@ public class JenkinsMockClient implements JenkinsClient {
 	}
 
 	@Override
-	public boolean isLastProdPipelineBuildInError(String patchNumber) {
-		LOGGER.info("isLastProdPipelineBuildInError for : " + patchNumber);
-		return true;
+	public BuildResult getProdPipelineBuildResult(String patchNumber) {
+		LOGGER.info("getProdPipelineBuildResult for : " + patchNumber);
+		return BuildResult.ABORTED;
 	}
-
-	@Override
-	public boolean isLastProdPipelineBuildAborted(String patchNumber) {
-		LOGGER.info("isLastProdPipelineBuildAborted : " + patchNumber);
-		return true;
-	}	
 }

--- a/apg-patch-service-server/src/main/resources/messages.properties
+++ b/apg-patch-service-server/src/main/resources/messages.properties
@@ -15,7 +15,7 @@ SimplePatchContainerBean.startInstallPipeline.patch.exists.assert=Patch: {0} to 
 SimplePatchContainerBean.restartProdPipeline.patchnumber.notnull.assert=Patchnumber null for restartProdPipeline
 SimplePatchContainerBean.restartProdPipeline.patch.exists.assert=Patch with Patchnumber: {0} to restartProdPipeline not found
 SimplePatchContainerBean.restartProdPipeline.patch.alreadyRunning=Patch {0} can not be restarted as he is already running
-SimplePatchContainerBean.restartProdPipeline.patch.lastBuildInError=Patch {0} can not be restarted as the last build did not end with an error
+SimplePatchContainerBean.restartProdPipeline.patch.lastBuildInErrorOrAborted=Patch {0} can not be restarted as the last build did not end with an error or has not been aborted
 SimplePatchContainerBean.log.patchisnull=Cannot log patch info as following patch has not been found: {0}
 SimplePatchContainerBean.log.patchnumber.isnullorempty=Cannot log patch info for null or empty patch number
 SimplePatchContainerBean.log.patch.null.assert=Cannot log patch info for null patch object
@@ -59,6 +59,6 @@ Groovy.script.executePatchAction.configfile.exists.assert=Config File {0} does n
 Groovy.script.executePatchAction.state.exits.assert=Invalid to state: {0} for Patch: {1}
 JenkinsAdminClientImpl.startPipeline.error=Starting onClone pipeline failed for target {0}
 JenkinsPatchClientImpl.isProdPipelineForPatchRunning.error=Could not determine if patch {0} is already running
-JenkinsPatchClientImpl.isLastProdPipelineBuildInError.error=Could not determine if last prod pipeline for patch {0} ended with an error
+JenkinsPatchClientImpl.matchLastProdPipelineBuildResult.error=Could not determine result of last build for patch {0}
 
 

--- a/apg-patch-service-server/src/main/resources/messages.properties
+++ b/apg-patch-service-server/src/main/resources/messages.properties
@@ -59,6 +59,6 @@ Groovy.script.executePatchAction.configfile.exists.assert=Config File {0} does n
 Groovy.script.executePatchAction.state.exits.assert=Invalid to state: {0} for Patch: {1}
 JenkinsAdminClientImpl.startPipeline.error=Starting onClone pipeline failed for target {0}
 JenkinsPatchClientImpl.isProdPipelineForPatchRunning.error=Could not determine if patch {0} is already running
-JenkinsPatchClientImpl.matchLastProdPipelineBuildResult.error=Could not determine result of last build for patch {0}
+JenkinsPatchClientImpl.getProdPipelineBuildResult.error=Could not get BuildResult of last build for patch {0}
 
 


### PR DESCRIPTION
In order not to have unwanted behaviors, I kept the pre-condition with the "failed" pipeline, but added as well the "aborted" scenario.
What do you guys think? 
Ideally we could patch this one together with JAVA8MIG-732, where we'll anyway have to install a new version of Piper.