### PR TITLE
java8mig-748 / IT21-CM-GUI: Suche nach bestimmten Java-Artifakten

### DIFF
--- a/apg-patch-service-client/src/main/java/com/apgsga/microservice/patch/client/MicroservicePatchClient.java
+++ b/apg-patch-service-client/src/main/java/com/apgsga/microservice/patch/client/MicroservicePatchClient.java
@@ -44,6 +44,8 @@ public class MicroservicePatchClient implements PatchService {
 	private static final String LIST_INSTALLTARGETS = "/listInstallationTargets/{requestingTarget}";
 
 	private static final String REMOVE = "/remove";
+	
+	private static final String FIND_WITH_OBJECT_NAME = "/findWithObjectName";
 
 	protected static Log LOGGER = LogFactory.getLog(MicroservicePatchClient.class.getName());
 
@@ -168,6 +170,12 @@ public class MicroservicePatchClient implements PatchService {
 	@Override
 	public List<Patch> findByIds(List<String> patchIds) {
 		Patch[] result = restTemplate.postForEntity(getRestBaseUri() + FIND_BY_IDS, patchIds, Patch[].class).getBody();
+		return Lists.newArrayList(result);
+	}
+
+	@Override
+	public List<Patch> findWithObjectName(String objectName) {
+		Patch[] result = restTemplate.postForEntity(getRestBaseUri() + FIND_WITH_OBJECT_NAME, objectName, Patch[].class).getBody();
 		return Lists.newArrayList(result);
 	}
 }

--- a/apg-patch-service-client/src/test/java/com/apgsga/microservice/patch/client/MicroServicePatchClientTest.java
+++ b/apg-patch-service-client/src/test/java/com/apgsga/microservice/patch/client/MicroServicePatchClientTest.java
@@ -26,6 +26,8 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.FileCopyUtils;
 
+import com.apgsga.microservice.patch.api.DbObject;
+import com.apgsga.microservice.patch.api.MavenArtifact;
 import com.apgsga.microservice.patch.api.Patch;
 import com.apgsga.microservice.patch.api.PatchLog;
 import com.apgsga.microservice.patch.api.PatchPersistence;
@@ -178,5 +180,37 @@ public class MicroServicePatchClientTest {
 		Assert.assertNotNull(pl);
 	}
 	
-
+	@Test
+	public void testFindWithObjectName() { 		
+		Patch p1 = new PatchBean();
+		p1.setPatchNummer("p1");
+		Patch p2 = new PatchBean();
+		p2.setPatchNummer("p2");
+		patchClient.save(p1);
+		patchClient.save(p2);
+		Assert.assertNotNull(patchClient.findById("p1"));
+		Assert.assertNotNull(patchClient.findById("p2"));
+		MavenArtifact ma1 = new MavenArtifactBean("test-ma1", "com.apgsga", "1.0");
+		MavenArtifact ma2 = new MavenArtifactBean("test-ma2", "com.apgsga", "1.0");
+		MavenArtifact ma3 = new MavenArtifactBean("test-ma3", "com.apgsga", "1.0");
+		DbObject db1 = new DbObjectBean("test-db1", "com.apgsga.ch/sql/db/test-db1");
+		db1.setModuleName("test-db1");
+		DbObject db2 = new DbObjectBean("test-db2", "com.apgsga.ch/sql/db/test-db2");
+		db2.setModuleName("test-db2");		
+		p1.addDbObjects(db1);
+		p1.addDbObjects(db2);
+		p1.addMavenArtifacts(ma1);
+		p2.addMavenArtifacts(ma2);
+		p1.addMavenArtifacts(ma3);
+		p2.addMavenArtifacts(ma3);
+		patchClient.save(p1);
+		patchClient.save(p2);
+		Assert.assertTrue(patchClient.findById("p1").getMavenArtifacts().size() == 2);
+		Assert.assertTrue(patchClient.findById("p2").getMavenArtifacts().size() == 2);
+		Assert.assertTrue(patchClient.findWithObjectName("ma1").size() == 1);
+		Assert.assertTrue(patchClient.findWithObjectName("ma2").size() == 1);
+		Assert.assertTrue(patchClient.findWithObjectName("ma3").size() == 2);
+		Assert.assertTrue(patchClient.findWithObjectName("wrongName").size() == 0);
+		Assert.assertTrue(patchClient.findWithObjectName("test-db2").size() == 1);
+	}
 }

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchServiceClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchServiceClient.groovy
@@ -182,4 +182,9 @@ class PatchServiceClient implements PatchOpService, PatchPersistence {
 			System.err.println "Error output : " + response.body.getText("UTF-8")
 		}
 	}
+
+	@Override
+	public List<Patch> findWithObjectName(String objectName) {
+		throw new UnsupportedOperationException("findWithObjectName not supported by client");
+	}
 }

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchServiceClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchServiceClient.groovy
@@ -182,9 +182,4 @@ class PatchServiceClient implements PatchOpService, PatchPersistence {
 			System.err.println "Error output : " + response.body.getText("UTF-8")
 		}
 	}
-
-	@Override
-	public List<Patch> findWithObjectName(String objectName) {
-		throw new UnsupportedOperationException("findWithObjectName not supported by client");
-	}
 }

--- a/apg-patch-service-common/src/main/java/com/apgsga/microservice/patch/api/PatchPersistence.java
+++ b/apg-patch-service-common/src/main/java/com/apgsga/microservice/patch/api/PatchPersistence.java
@@ -36,5 +36,6 @@ public interface PatchPersistence {
 	public void clean();
 
 	public void init() throws IOException;
-
+	
+	public List<Patch> findWithObjectName(String objectName);
 }

--- a/apg-patch-service-common/src/main/java/com/apgsga/microservice/patch/api/PatchPersistence.java
+++ b/apg-patch-service-common/src/main/java/com/apgsga/microservice/patch/api/PatchPersistence.java
@@ -36,6 +36,4 @@ public interface PatchPersistence {
 	public void clean();
 
 	public void init() throws IOException;
-	
-	public List<Patch> findWithObjectName(String objectName);
 }

--- a/apg-patch-service-common/src/main/java/com/apgsga/microservice/patch/api/PatchService.java
+++ b/apg-patch-service-common/src/main/java/com/apgsga/microservice/patch/api/PatchService.java
@@ -97,5 +97,12 @@ public interface PatchService {
 	 * @throws PatchContainerException
 	 */
 	public void remove(Patch patch);
+	
+	/**
+	 * Search for patches which contains given object name
+	 * @param objectName name of searched object
+	 * @return List of patches containing Object with given name
+	 */
+	public List<Patch> findWithObjectName(String objectName);
 
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/MicroServicePatchController.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/MicroServicePatchController.java
@@ -139,4 +139,11 @@ public class MicroServicePatchController implements PatchService {
 	public PatchLog findPatchLogById(@PathVariable("id") String patchNummer) {
 		return patchService.findPatchLogById(patchNummer);
 	}
+
+	@RequestMapping(value = "/findWithObjectName", method = RequestMethod.POST)
+	@ResponseBody
+	@Override
+	public List<Patch> findWithObjectName(@RequestBody String objectName) {
+		return patchService.findWithObjectName(objectName);
+	}
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/PatchOpServiceController.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/PatchOpServiceController.java
@@ -191,4 +191,11 @@ public class PatchOpServiceController implements PatchOpService, PatchPersistenc
 	public void cleanLocalMavenRepo() {
 		patchService.cleanLocalMavenRepo();
 	}
+
+	@RequestMapping(value = "/findWithObjectName", method = RequestMethod.POST)
+	@ResponseBody
+	@Override
+	public List<Patch> findWithObjectName(@RequestBody String objectName) {
+		return repo.findWithObjectName(objectName);
+	}
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/PatchOpServiceController.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/PatchOpServiceController.java
@@ -191,11 +191,4 @@ public class PatchOpServiceController implements PatchOpService, PatchPersistenc
 	public void cleanLocalMavenRepo() {
 		patchService.cleanLocalMavenRepo();
 	}
-
-	@RequestMapping(value = "/findWithObjectName", method = RequestMethod.POST)
-	@ResponseBody
-	@Override
-	public List<Patch> findWithObjectName(@RequestBody String objectName) {
-		return repo.findWithObjectName(objectName);
-	}
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/SimplePatchContainerBean.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/SimplePatchContainerBean.java
@@ -354,4 +354,9 @@ public class SimplePatchContainerBean implements PatchService, PatchOpService {
 	public TaskExecutor getThreadExecutor() {
 		return threadExecutor;
 	}
+
+	@Override
+	public List<Patch> findWithObjectName(String objectName) {
+		return repo.findWithObjectName(objectName);
+	}
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/persistence/FilebasedPatchPersistence.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/persistence/FilebasedPatchPersistence.java
@@ -4,9 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -15,8 +13,6 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.core.io.Resource;
 
 import com.apgsga.microservice.patch.api.DbModules;
-import com.apgsga.microservice.patch.api.DbObject;
-import com.apgsga.microservice.patch.api.MavenArtifact;
 import com.apgsga.microservice.patch.api.Patch;
 import com.apgsga.microservice.patch.api.PatchLog;
 import com.apgsga.microservice.patch.api.PatchLogDetails;
@@ -296,29 +292,5 @@ public class FilebasedPatchPersistence implements PatchPersistence {
 
 	public Resource getTempStoragePath() {
 		return tempStoragePath;
-	}
-
-	@Override
-	public List<Patch> findWithObjectName(String objectName) {
-		List<String> patchFiles = listFiles(PATCH);
-		// Filter out "PatchLog" files, and extract Id from patch name
-		List<String> patchFilesReduced = patchFiles.stream().filter(pat -> !pat.contains(PATCH_LOG)).map(pat -> pat.substring(pat.indexOf(PATCH)+PATCH.length(),pat.indexOf(JSON))).collect(Collectors.toList());
-		return patchFilesReduced.stream().filter(p -> containsObject(p,objectName)).map(p -> findById(p)).collect(Collectors.toList());
-	}
-	
-	private boolean containsObject(String patchNumber, String objectName) {
-		Patch patch = findById(patchNumber);
-		for(MavenArtifact ma : patch.getMavenArtifacts()) {
-			// TODO JHE : verifiy if we really want to check only on artifact id, maybe also on name?
-			if(ma.getArtifactId()!= null && ma.getArtifactId().toUpperCase().contains(objectName.toUpperCase()))
-				return true;
-		}
-		for(DbObject dbo : patch.getDbObjects()) {
-			// TODO JHE : verifiy if we really want to check on moduleName
-			if(dbo.getModuleName() != null && dbo.getModuleName().toUpperCase().contains(objectName.toUpperCase())) {
-				return true;
-			}
-		}
-		return false;
 	}
 }

--- a/apg-patch-service-server/src/test/java/com/apgsga/microservice/patch/server/MicroServicePatchServerTest.java
+++ b/apg-patch-service-server/src/test/java/com/apgsga/microservice/patch/server/MicroServicePatchServerTest.java
@@ -21,6 +21,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import com.apgsga.microservice.patch.api.DbObject;
+import com.apgsga.microservice.patch.api.MavenArtifact;
 import com.apgsga.microservice.patch.api.Patch;
 import com.apgsga.microservice.patch.api.PatchLog;
 import com.apgsga.microservice.patch.api.PatchLogDetails;
@@ -189,6 +191,40 @@ public class MicroServicePatchServerTest {
 		patchService.save(patch);
 		PatchActionExecutor patchActionExecutor = patchActionFactory.create(patchService);
 		patchActionExecutor.execute("SomeUnqiueNumber3", "Entwicklung");
+	}
+	
+	@Test
+	public void testFindWithObjectName() {
+		Patch p1 = new PatchBean();
+		p1.setPatchNummer("p1");
+		Patch p2 = new PatchBean();
+		p2.setPatchNummer("p2");
+		patchService.save(p1);
+		patchService.save(p2);
+		Assert.assertNotNull(patchService.findById("p1"));
+		Assert.assertNotNull(patchService.findById("p2"));
+		MavenArtifact ma1 = new MavenArtifactBean("test-ma1", "com.apgsga", "1.0");
+		MavenArtifact ma2 = new MavenArtifactBean("test-ma2", "com.apgsga", "1.0");
+		MavenArtifact ma3 = new MavenArtifactBean("test-ma3", "com.apgsga", "1.0");
+		DbObject db1 = new DbObjectBean("test-db1", "com.apgsga.ch/sql/db/test-db1");
+		db1.setModuleName("test-db1");
+		DbObject db2 = new DbObjectBean("test-db2", "com.apgsga.ch/sql/db/test-db2");
+		db2.setModuleName("test-db2");		
+		p1.addDbObjects(db1);
+		p1.addDbObjects(db2);
+		p1.addMavenArtifacts(ma1);
+		p2.addMavenArtifacts(ma2);
+		p1.addMavenArtifacts(ma3);
+		p2.addMavenArtifacts(ma3);
+		patchService.save(p1);
+		patchService.save(p2);
+		Assert.assertTrue(patchService.findById("p1").getMavenArtifacts().size() == 2);
+		Assert.assertTrue(patchService.findById("p2").getMavenArtifacts().size() == 2);
+		Assert.assertTrue(patchService.findWithObjectName("ma1").size() == 1);
+		Assert.assertTrue(patchService.findWithObjectName("ma2").size() == 1);
+		Assert.assertTrue(patchService.findWithObjectName("ma3").size() == 2);
+		Assert.assertTrue(patchService.findWithObjectName("wrongName").size() == 0);
+		Assert.assertTrue(patchService.findWithObjectName("test-db2").size() == 1);
 	}
 
 }

--- a/apg-patch-service-server/src/test/java/com/apgsga/microservice/patch/server/impl/persistence/FilebasedPersistenceTest.java
+++ b/apg-patch-service-server/src/test/java/com/apgsga/microservice/patch/server/impl/persistence/FilebasedPersistenceTest.java
@@ -23,12 +23,14 @@ import org.springframework.util.FileCopyUtils;
 
 import com.apgsga.microservice.patch.api.DbModules;
 import com.apgsga.microservice.patch.api.DbObject;
+import com.apgsga.microservice.patch.api.MavenArtifact;
 import com.apgsga.microservice.patch.api.Patch;
 import com.apgsga.microservice.patch.api.PatchPersistence;
 import com.apgsga.microservice.patch.api.ServiceMetaData;
 import com.apgsga.microservice.patch.api.ServicesMetaData;
 import com.apgsga.microservice.patch.api.impl.DbObjectBean;
 import com.apgsga.microservice.patch.api.impl.MavenArtifactBean;
+import com.apgsga.microservice.patch.api.impl.PatchBean;
 import com.apgsga.microservice.patch.api.impl.ServiceMetaDataBean;
 import com.apgsga.microservice.patch.api.impl.ServicesMetaDataBean;
 
@@ -149,6 +151,40 @@ public class FilebasedPersistenceTest {
 		repo.saveServicesMetaData(data);
 		ServicesMetaData serviceData = repo.getServicesMetaData();
 		assertEquals(data, serviceData);
+	}
+	
+	@Test
+	public void testFindWithObjectName() {
+		Patch p1 = new PatchBean();
+		p1.setPatchNummer("p1");
+		Patch p2 = new PatchBean();
+		p2.setPatchNummer("p2");
+		repo.savePatch(p1);
+		repo.savePatch(p2);
+		Assert.assertNotNull(repo.findById("p1"));
+		Assert.assertNotNull(repo.findById("p2"));
+		MavenArtifact ma1 = new MavenArtifactBean("test-ma1", "com.apgsga", "1.0");
+		MavenArtifact ma2 = new MavenArtifactBean("test-ma2", "com.apgsga", "1.0");
+		MavenArtifact ma3 = new MavenArtifactBean("test-ma3", "com.apgsga", "1.0");
+		DbObject db1 = new DbObjectBean("test-db1", "com.apgsga.ch/sql/db/test-db1");
+		db1.setModuleName("test-db1");
+		DbObject db2 = new DbObjectBean("test-db2", "com.apgsga.ch/sql/db/test-db2");
+		db2.setModuleName("test-db2");		
+		p1.addDbObjects(db1);
+		p1.addDbObjects(db2);
+		p1.addMavenArtifacts(ma1);
+		p2.addMavenArtifacts(ma2);
+		p1.addMavenArtifacts(ma3);
+		p2.addMavenArtifacts(ma3);
+		repo.savePatch(p1);
+		repo.savePatch(p2);
+		Assert.assertTrue(repo.findById("p1").getMavenArtifacts().size() == 2);
+		Assert.assertTrue(repo.findById("p2").getMavenArtifacts().size() == 2);
+		Assert.assertTrue(repo.findWithObjectName("ma1").size() == 1);
+		Assert.assertTrue(repo.findWithObjectName("ma2").size() == 1);
+		Assert.assertTrue(repo.findWithObjectName("ma3").size() == 2);
+		Assert.assertTrue(repo.findWithObjectName("wrongName").size() == 0);
+		Assert.assertTrue(repo.findWithObjectName("test-db2").size() == 1);
 	}
 
 }

--- a/apg-patch-service-server/src/test/java/com/apgsga/microservice/patch/server/impl/persistence/FilebasedPersistenceTest.java
+++ b/apg-patch-service-server/src/test/java/com/apgsga/microservice/patch/server/impl/persistence/FilebasedPersistenceTest.java
@@ -152,39 +152,4 @@ public class FilebasedPersistenceTest {
 		ServicesMetaData serviceData = repo.getServicesMetaData();
 		assertEquals(data, serviceData);
 	}
-	
-	@Test
-	public void testFindWithObjectName() {
-		Patch p1 = new PatchBean();
-		p1.setPatchNummer("p1");
-		Patch p2 = new PatchBean();
-		p2.setPatchNummer("p2");
-		repo.savePatch(p1);
-		repo.savePatch(p2);
-		Assert.assertNotNull(repo.findById("p1"));
-		Assert.assertNotNull(repo.findById("p2"));
-		MavenArtifact ma1 = new MavenArtifactBean("test-ma1", "com.apgsga", "1.0");
-		MavenArtifact ma2 = new MavenArtifactBean("test-ma2", "com.apgsga", "1.0");
-		MavenArtifact ma3 = new MavenArtifactBean("test-ma3", "com.apgsga", "1.0");
-		DbObject db1 = new DbObjectBean("test-db1", "com.apgsga.ch/sql/db/test-db1");
-		db1.setModuleName("test-db1");
-		DbObject db2 = new DbObjectBean("test-db2", "com.apgsga.ch/sql/db/test-db2");
-		db2.setModuleName("test-db2");		
-		p1.addDbObjects(db1);
-		p1.addDbObjects(db2);
-		p1.addMavenArtifacts(ma1);
-		p2.addMavenArtifacts(ma2);
-		p1.addMavenArtifacts(ma3);
-		p2.addMavenArtifacts(ma3);
-		repo.savePatch(p1);
-		repo.savePatch(p2);
-		Assert.assertTrue(repo.findById("p1").getMavenArtifacts().size() == 2);
-		Assert.assertTrue(repo.findById("p2").getMavenArtifacts().size() == 2);
-		Assert.assertTrue(repo.findWithObjectName("ma1").size() == 1);
-		Assert.assertTrue(repo.findWithObjectName("ma2").size() == 1);
-		Assert.assertTrue(repo.findWithObjectName("ma3").size() == 2);
-		Assert.assertTrue(repo.findWithObjectName("wrongName").size() == 0);
-		Assert.assertTrue(repo.findWithObjectName("test-db2").size() == 1);
-	}
-
 }

--- a/apg-patch-service-server/src/test/java/com/apgsga/microservice/patch/server/impl/persistence/FilebasedPersistenceTest.java
+++ b/apg-patch-service-server/src/test/java/com/apgsga/microservice/patch/server/impl/persistence/FilebasedPersistenceTest.java
@@ -23,14 +23,12 @@ import org.springframework.util.FileCopyUtils;
 
 import com.apgsga.microservice.patch.api.DbModules;
 import com.apgsga.microservice.patch.api.DbObject;
-import com.apgsga.microservice.patch.api.MavenArtifact;
 import com.apgsga.microservice.patch.api.Patch;
 import com.apgsga.microservice.patch.api.PatchPersistence;
 import com.apgsga.microservice.patch.api.ServiceMetaData;
 import com.apgsga.microservice.patch.api.ServicesMetaData;
 import com.apgsga.microservice.patch.api.impl.DbObjectBean;
 import com.apgsga.microservice.patch.api.impl.MavenArtifactBean;
-import com.apgsga.microservice.patch.api.impl.PatchBean;
 import com.apgsga.microservice.patch.api.impl.ServiceMetaDataBean;
 import com.apgsga.microservice.patch.api.impl.ServicesMetaDataBean;
 


### PR DESCRIPTION
Ability to get list of Patches containing a given module name. Module can either be a Java Artifact of a DB Module.
As in code commented, we might want to change on which field the research will be made, this can easily be change. For now, the research would be done:
- On ArtifactId for MavenArtifact objects
- On ModuleName for DBObject
GUI will obviously also have to be updated, but this one can (has to) go in production first.
