### PR TITLE
ARCH-96 / Liste von "Revisions" für ein bestimmten Umgebung

### DIFF
--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/revision/PatchRevisionCli.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/revision/PatchRevisionCli.groovy
@@ -53,6 +53,11 @@ class PatchRevisionCli {
 				def result = resetRevisions(options)
 				cmdResults.results['rr'] = result
 			}
+			
+			if(options.gr) {
+				def result = getRevisions(options)
+				cmdResults.results['gr'] = result
+			}
 						
 			cmdResults.returnCode = 0
 			return cmdResults
@@ -96,6 +101,11 @@ class PatchRevisionCli {
 		patchRevClient.resetRevisions(options.rrs[0].toUpperCase(), options.rrs[1].toUpperCase())
 	}
 	
+	private def getRevisions(def options) {
+		def patchRevClient = new PatchRevisionClient(config)
+		patchRevClient.getRevisions(options.grs[0].toUpperCase())
+	}
+	
 	private def validateOpts(def args) {
 		def cli = new CliBuilder (usage: 'apsrevpli.sh -[h|ar|lr|nr|rr]')
 		cli.formatter.setDescPadding(0)
@@ -110,6 +120,7 @@ class PatchRevisionCli {
 			rr longOpt: 'resetRevision', args:2, valueSeparator: ",", argName: 'source,target', 'Reset the revision list and last revision for the given target', required: false
 			// TODO JHE: to be implemented, probably while working on JAVA8MIG-431
 			i longOpt: 'initRevision', args:0 , 'Initialize the Revision Tracking', required: false
+			gr longOpt: 'getRevision', args:1, argName: 'target', 'Get all revisions for the given target', required: false
 		}
 		
 		def options = cli.parse(args)
@@ -124,7 +135,7 @@ class PatchRevisionCli {
 			return null
 		}
 		
-		if (options.nr || options.lr || options.rr || options.llr) {
+		if (options.nr || options.lr || options.rr || options.llr || options.gr) {
 			error = false
 		}
 

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/revision/PatchRevisionClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/revision/PatchRevisionClient.groovy
@@ -1,5 +1,7 @@
 package com.apgsga.patch.service.client.revision
 
+import java.util.stream.Collectors
+
 import groovy.json.JsonBuilder
 import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
@@ -103,9 +105,7 @@ class PatchRevisionClient {
 		def revisionsList = []
 		def revFileAsJson = new JsonSlurper().parse(revisionFile)
 		if(revFileAsJson."${target}" != null) {
-			revFileAsJson."${target}".revisions.each { revision -> 
-				revisionsList.add(revision)
-			}
+			revisionsList = revFileAsJson."${target}".revisions.stream().collect(Collectors.toList())
 		}
 		println revisionsList.join(",")
 	}

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/revision/PatchRevisionClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/revision/PatchRevisionClient.groovy
@@ -98,4 +98,15 @@ class PatchRevisionClient {
 			}
 		}
 	}
+	
+	def getRevisions(def target) {
+		def revisionsList = []
+		def revFileAsJson = new JsonSlurper().parse(revisionFile)
+		if(revFileAsJson."${target}" != null) {
+			revFileAsJson."${target}".revisions.each { revision -> 
+				revisionsList.add(revision)
+			}
+		}
+		println revisionsList.join(",")
+	}
 }

--- a/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/RevisionCliIntegrationTest.groovy
+++ b/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/RevisionCliIntegrationTest.groovy
@@ -344,4 +344,35 @@ class RevisionCliIntegrationTest extends Specification {
 		cleanup:
 			revFile.delete()
 	}
+	
+	def "Patch Revision Cli validate get List of Revision for a particular target"() {
+		when:
+			PatchRevisionCli cli = PatchRevisionCli.create()
+			def revFile = new File("src/test/resources/Revisions.json")
+			cli.process(["-ar","chti211,18,9.1.0.ADMIN-UIMIG-"])
+			cli.process(["-ar","chei212,77,9.1.0.ADMIN-UIMIG-"])
+			cli.process(["-ar","chei212,88,9.1.0.ADMIN-UIMIG-"])
+			cli.process(["-ar","chti211,185,9.1.0.ADMIN-UIMIG-"])
+			cli.process(["-ar","chei212,100,9.1.0.ADMIN-UIMIG-"])
+			cli.process(["-ar","chei211,50,9.1.0.ADMIN-UIMIG-"])
+			cli.process(["-ar","chpi211,5000,9.1.0.ADMIN-UIMIG-"])
+			cli.process(["-ar","chpi211,6000,9.1.0.ADMIN-UIMIG-"])
+			cli.process(["-ar","chpi211,7000,9.1.0.ADMIN-UIMIG-"])
+			cli.process(["-ar","chpi211,8000,9.1.0.ADMIN-UIMIG-"])
+			def oldStream = System.out;
+			def buffer = new ByteArrayOutputStream()
+			System.setOut(new PrintStream(buffer))
+			def result = cli.process(["-gr","chpi211"])
+		then:
+			System.setOut(oldStream)
+			revFile.exists()
+			result.returnCode == 0
+			buffer.toString().toString().split(",").size() == 4
+			buffer.toString().toString().contains("9.1.0.ADMIN-UIMIG-5000")
+			buffer.toString().toString().contains("9.1.0.ADMIN-UIMIG-6000")
+			buffer.toString().toString().contains("9.1.0.ADMIN-UIMIG-7000")
+			buffer.toString().toString().contains("9.1.0.ADMIN-UIMIG-8000")
+		cleanup:
+			revFile.delete()
+	}
 }


### PR DESCRIPTION
This is a requirement for ARCH-42, where we need to get all the revisions which have been installed on Production. 
This has been successfully tested on jenkins-t, with for example following command:

`apsrevcli.sh -gr dev-ondemand`
