### PR TITLE
ARCH-101 / delete Revision list for a target

### DIFF
--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/revision/PatchRevisionCli.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/revision/PatchRevisionCli.groovy
@@ -58,6 +58,11 @@ class PatchRevisionCli {
 				def result = getRevisions(options)
 				cmdResults.results['gr'] = result
 			}
+			
+			if(options.dr) {
+				def result = deleteRevisions(options)
+				cmdResults.results['dr'] = result
+			}
 						
 			cmdResults.returnCode = 0
 			return cmdResults
@@ -106,8 +111,13 @@ class PatchRevisionCli {
 		patchRevClient.getRevisions(options.grs[0].toUpperCase())
 	}
 	
+	private def deleteRevisions(def options) {
+		def patchRevClient = new PatchRevisionClient(config)
+		def res = patchRevClient.deleteRevisions(options.drs[0].toUpperCase())
+	}
+	
 	private def validateOpts(def args) {
-		def cli = new CliBuilder (usage: 'apsrevpli.sh -[h|ar|lr|nr|rr]')
+		def cli = new CliBuilder (usage: 'apsrevpli.sh -[h|ar|lr|nr|rr|gr|dr]')
 		cli.formatter.setDescPadding(0)
 		cli.formatter.setLeftPadding(0)
 		cli.formatter.setWidth(100)
@@ -121,6 +131,7 @@ class PatchRevisionCli {
 			// TODO JHE: to be implemented, probably while working on JAVA8MIG-431
 			i longOpt: 'initRevision', args:0 , 'Initialize the Revision Tracking', required: false
 			gr longOpt: 'getRevision', args:1, argName: 'target', 'Get all revisions for the given target', required: false
+			dr longOpt: 'deleteRevision', args:1, argName: 'target', 'Delete all Revisions number for the given target (lastRevision remains)'
 		}
 		
 		def options = cli.parse(args)
@@ -135,7 +146,7 @@ class PatchRevisionCli {
 			return null
 		}
 		
-		if (options.nr || options.lr || options.rr || options.llr || options.gr) {
+		if (options.nr || options.lr || options.rr || options.gr || options.dr) {
 			error = false
 		}
 

--- a/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/DbCliIntegrationTest.groovy
+++ b/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/DbCliIntegrationTest.groovy
@@ -20,6 +20,8 @@ import spock.lang.Specification
 
 
 class DbCliIntegrationTest extends Specification {
+	
+	//test commit in a branch linked to a closed pull request ...
 
 	private static final String CLASSPATH_CONFIG_OPS_TEST_PROPERTIES = 'classpath:config/ops-test.properties'
 


### PR DESCRIPTION
Provide ability to delete the revision list within Revisions.json file for a given target, except for the one deinfe as production within TargetSystemMappings.json.
This tool only delete the list within Revisions.json, and nothing on Artifactory.
This has been successfuly testen on jenkins-t.