### PR TITLE
CM-226 / concurrency problem

### DIFF
--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/persistence/FilebasedPatchPersistence.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/impl/persistence/FilebasedPatchPersistence.java
@@ -267,7 +267,7 @@ public class FilebasedPatchPersistence implements PatchPersistence {
 		return result.get(0);
 	}
 
-	private <T> void writeToFile(T object, String filename) {
+	private synchronized <T> void writeToFile(T object, String filename) {
 		ObjectMapper mapper = new ObjectMapper();
 		String jsonRequestString;
 		try {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ project.ext {
 allprojects  {
 	apply plugin: 'maven'
 	group = 'com.apgsga.patchframework'
-	version  = '1.3.17'
+	version  = '1.3.19'
 }
 subprojects {
 	apply plugin: 'java'


### PR DESCRIPTION
"savePatch" and "savePatchLog" are 2 different methods which are calling the same function in order to write content in 2 different files. 
We had the case where "savePatch" was trying to write into the patchLog file ... see also the stacktrace within https://jira.apgsga.ch/browse/CM-226