### PR TITLE
IT-36392 / apscli, start a job with file parameter

### DIFF
--- a/apg-patch-service-api/src/main/java/com/apgsga/microservice/patch/api/JenkinsParameterType.java
+++ b/apg-patch-service-api/src/main/java/com/apgsga/microservice/patch/api/JenkinsParameterType.java
@@ -1,0 +1,5 @@
+package com.apgsga.microservice.patch.api;
+
+public enum JenkinsParameterType {
+    STRING_PARAM,FILE_PARAM
+}

--- a/apg-patch-service-api/src/main/java/com/apgsga/microservice/patch/api/JenkinsParameterType.java
+++ b/apg-patch-service-api/src/main/java/com/apgsga/microservice/patch/api/JenkinsParameterType.java
@@ -1,5 +1,0 @@
-package com.apgsga.microservice.patch.api;
-
-public enum JenkinsParameterType {
-    STRING_PARAM,FILE_PARAM
-}

--- a/apg-patch-service-api/src/main/java/com/apgsga/microservice/patch/api/PatchOpService.java
+++ b/apg-patch-service-api/src/main/java/com/apgsga/microservice/patch/api/PatchOpService.java
@@ -49,6 +49,12 @@ public interface PatchOpService extends PatchRdbms {
 	void startInstallPipeline(String target);
 
 	/**
+	 * Starts the corresponding build (or compile) pipeline
+	 * @param patchNumber eg.: 3456
+	 */
+	void startJenkinsBuildPipeline(String patchNumber);
+
+	/**
 	 * Copies JSON Patch files to a destination folder
 	 * @param params : 2 parameters required with following keys: "status" and "destFolder"
 	 */
@@ -63,8 +69,8 @@ public interface PatchOpService extends PatchRdbms {
 	/**
 	 *
 	 * @param jobName
-	 * @param params key contains the type of Parameter
-	 *               value is a standard Map, key=value for each parameter
+	 * @param params Standard key=value parameters Map
+	 *
 	 */
-	void startJenkinsJob(String jobName, Map<JenkinsParameterType,Map> params);
+	void startJenkinsJob(String jobName, Map<String,String> params);
 }

--- a/apg-patch-service-api/src/main/java/com/apgsga/microservice/patch/api/PatchOpService.java
+++ b/apg-patch-service-api/src/main/java/com/apgsga/microservice/patch/api/PatchOpService.java
@@ -2,7 +2,6 @@ package com.apgsga.microservice.patch.api;
 
 import com.apgsga.patch.db.integration.api.PatchRdbms;
 
-import java.io.File;
 import java.util.Map;
 
 public interface PatchOpService extends PatchRdbms {

--- a/apg-patch-service-api/src/main/java/com/apgsga/microservice/patch/api/PatchOpService.java
+++ b/apg-patch-service-api/src/main/java/com/apgsga/microservice/patch/api/PatchOpService.java
@@ -2,6 +2,7 @@ package com.apgsga.microservice.patch.api;
 
 import com.apgsga.patch.db.integration.api.PatchRdbms;
 
+import java.io.File;
 import java.util.Map;
 
 public interface PatchOpService extends PatchRdbms {
@@ -62,7 +63,8 @@ public interface PatchOpService extends PatchRdbms {
 	/**
 	 *
 	 * @param jobName
-	 * @param jobParams key=paramName, value=paramValue -> for each job parameter
+	 * @param params key contains the type of Parameter: STANDARD_P or FILE_P
+	 *               value is a standard Map, key=value for each parameter
 	 */
-	void startJenkinsJob(String jobName, Map<String,String> jobParams);
+	void startJenkinsJob(String jobName, Map<JenkinsParameterType,Map> params);
 }

--- a/apg-patch-service-api/src/main/java/com/apgsga/microservice/patch/api/PatchOpService.java
+++ b/apg-patch-service-api/src/main/java/com/apgsga/microservice/patch/api/PatchOpService.java
@@ -63,7 +63,7 @@ public interface PatchOpService extends PatchRdbms {
 	/**
 	 *
 	 * @param jobName
-	 * @param params key contains the type of Parameter: STANDARD_P or FILE_P
+	 * @param params key contains the type of Parameter
 	 *               value is a standard Map, key=value for each parameter
 	 */
 	void startJenkinsJob(String jobName, Map<JenkinsParameterType,Map> params);

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchCli.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/PatchCli.groovy
@@ -299,7 +299,7 @@ class PatchCli {
 
 	}
 
-	private Map<String,File> fileParameterAsMap(def fileParams) {
+	private Map<String,String> fileParameterAsMap(def fileParams) {
 		if(fileParams == null) {
 			return null
 		}
@@ -309,7 +309,7 @@ class PatchCli {
 		def keyPair = fileParams.split("@:")
 		keyPair.each {kp ->
 			def values = kp.split("@=")
-			paramAsMap.put(values[0],new File(values[1]))
+			paramAsMap.put(values[0],values[1])
 		}
 
 		return paramAsMap

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/rest/PatchRestServiceClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/rest/PatchRestServiceClient.groovy
@@ -1,5 +1,6 @@
 package com.apgsga.patch.service.client.rest
 
+import com.apgsga.microservice.patch.api.JenkinsParameterType
 import com.apgsga.microservice.patch.api.Patch
 import com.apgsga.microservice.patch.api.PatchOpService
 import com.apgsga.patch.service.client.PatchCliExceptionHandler
@@ -87,8 +88,8 @@ class PatchRestServiceClient implements PatchOpService {
 	}
 
 	@Override
-	void startJenkinsJob(String jobName, Map<String, String> jobParams) {
-		restTemplate.postForLocation(getRestBaseUri() + "/startJenkinsJobWithParam/{jobName}",jobParams, [jobName:jobName]);
+	void startJenkinsJob(String jobName, Map<JenkinsParameterType, Map> params) {
+		restTemplate.postForLocation(getRestBaseUri() + "/startJenkinsJobWithParam/{jobName}",params, [jobName:jobName]);
 	}
 
 	class PatchServiceErrorHandler implements ResponseErrorHandler {

--- a/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/rest/PatchRestServiceClient.groovy
+++ b/apg-patch-service-cmdclient/src/main/groovy/com/apgsga/patch/service/client/rest/PatchRestServiceClient.groovy
@@ -1,6 +1,5 @@
 package com.apgsga.patch.service.client.rest
 
-import com.apgsga.microservice.patch.api.JenkinsParameterType
 import com.apgsga.microservice.patch.api.Patch
 import com.apgsga.microservice.patch.api.PatchOpService
 import com.apgsga.patch.service.client.PatchCliExceptionHandler
@@ -48,6 +47,11 @@ class PatchRestServiceClient implements PatchOpService {
 	}
 
 	@Override
+	void startJenkinsBuildPipeline(String patchNumber) {
+		restTemplate.postForLocation(getRestBaseUri() + "/startJenkinsBuildPipeline/{patchNumber}", null, [patchNumber:patchNumber]);
+	}
+
+	@Override
 	void copyPatchFiles(Map params) {
 		restTemplate.postForLocation(getRestBaseUri() + "/copyPatchFiles", params);
 	}
@@ -88,7 +92,7 @@ class PatchRestServiceClient implements PatchOpService {
 	}
 
 	@Override
-	void startJenkinsJob(String jobName, Map<JenkinsParameterType, Map> params) {
+	void startJenkinsJob(String jobName, Map<String,String> params) {
 		restTemplate.postForLocation(getRestBaseUri() + "/startJenkinsJobWithParam/{jobName}",params, [jobName:jobName]);
 	}
 

--- a/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/PatchCliIntegrationTest.groovy
+++ b/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/PatchCliIntegrationTest.groovy
@@ -243,16 +243,28 @@ class PatchCliIntegrationTest extends Specification {
 			repo.clean()
 	}
 
-	def "Patch cli startJenkinsJob with parameters" () {
+	def "Patch cli startJenkinsJob with string parameters" () {
 		setup:
 			def client = PatchCli.create()
 		when:
-			def result = client.process(["-sjp", 'testJob,param1@=value1@:p2@=v2@:testParam3@=thisisThirdValue'])
+			def result = client.process(["-sjsp", 'testJob,param1@=value1@:p2@=v2@:testParam3@=thisisThirdValue'])
 		then:
 			result.returnCode == 0
 			result.results != null
 		cleanup:
 			repo.clean()
+	}
+
+	def "Patch cli startJenkinsJob with file parameters" () {
+		setup:
+		def client = PatchCli.create()
+		when:
+		def result = client.process(["-sjfp", 'testJob,param1@=src/test/resources/Patch5401.json'])
+		then:
+		result.returnCode == 0
+		result.results != null
+		cleanup:
+		repo.clean()
 	}
 
 	// JHE (18.08.2020): Ignoring the test as it requires pre-requisite in DB. However, keeping it for future sanity checks

--- a/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/PatchCliIntegrationTest.groovy
+++ b/apg-patch-service-cmdclient/src/test/groovy/com/apgsga/patch/service/client/PatchCliIntegrationTest.groovy
@@ -53,11 +53,11 @@ class PatchCliIntegrationTest extends Specification {
 		try {
 			final ResourceLoader rl = new FileSystemResourceLoader();
 			Resource testResources = rl.getResource("src/test/resources");
-			File persistSt = new File(metaInfoDbLocation);
-			FileCopyUtils.copy(new File(testResources.getURI().getPath() + "/ServicesMetaData.json"), new File(persistSt, "ServicesMetaData.json"));
-			FileCopyUtils.copy(new File(testResources.getURI().getPath() + "/OnDemandTargets.json"), new File(persistSt, "OnDemandTargets.json"));
-			FileCopyUtils.copy(new File(testResources.getURI().getPath() + "/StageMappings.json"), new File(persistSt, "StageMappings.json"));
-			FileCopyUtils.copy(new File(testResources.getURI().getPath() + "/TargetInstances.json"), new File(persistSt, "TargetInstances.json"));
+			File metaInfoPersistFolder = new File(metaInfoDbLocation);
+			FileCopyUtils.copy(new File(testResources.getURI().getPath() + "/ServicesMetaData.json"), new File(metaInfoPersistFolder, "ServicesMetaData.json"));
+			FileCopyUtils.copy(new File(testResources.getURI().getPath() + "/OnDemandTargets.json"), new File(metaInfoPersistFolder, "OnDemandTargets.json"));
+			FileCopyUtils.copy(new File(testResources.getURI().getPath() + "/StageMappings.json"), new File(metaInfoPersistFolder, "StageMappings.json"));
+			FileCopyUtils.copy(new File(testResources.getURI().getPath() + "/TargetInstances.json"), new File(metaInfoPersistFolder, "TargetInstances.json"));
 		} catch (IOException e) {
 			Assert.fail("Unable to copy JSON test files into testDb folder");
 		}
@@ -247,7 +247,7 @@ class PatchCliIntegrationTest extends Specification {
 		setup:
 			def client = PatchCli.create()
 		when:
-			def result = client.process(["-sjsp", 'testJob,param1@=value1@:p2@=v2@:testParam3@=thisisThirdValue'])
+			def result = client.process(["-sjp", 'testJob,param1@=value1@:p2@=v2@:testParam3@=thisisThirdValue'])
 		then:
 			result.returnCode == 0
 			result.results != null
@@ -255,16 +255,21 @@ class PatchCliIntegrationTest extends Specification {
 			repo.clean()
 	}
 
-	def "Patch cli startJenkinsJob with file parameters" () {
+	def "Patch cli buildPipeline" () {
 		setup:
-		def client = PatchCli.create()
+			def client = PatchCli.create()
 		when:
-		def result = client.process(["-sjfp", 'testJob,param1@=src/test/resources/Patch5401.json'])
+			def resultSa = client.process(["-sa", "src/test/resources/Patch5401.json"])
+			def resultBp = client.process(["-bp", '5401'])
 		then:
-		result.returnCode == 0
-		result.results != null
+			resultSa.returnCode == 0
+			resultSa.results != null
+			File patchFile = new File("${dbLocation}/Patch5401.json")
+			patchFile.exists()
+			resultBp.returnCode == 0
+			resultBp.results != null
 		cleanup:
-		repo.clean()
+			repo.clean()
 	}
 
 	// JHE (18.08.2020): Ignoring the test as it requires pre-requisite in DB. However, keeping it for future sanity checks

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshBuildJobCmd.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshBuildJobCmd.java
@@ -49,6 +49,22 @@ public class JenkinsSshBuildJobCmd extends JenkinsSshCommand {
 
     @Override
     protected String[] getJenkinsCmd() {
+
+        List<String> tmpCmd = Lists.newArrayList();
+
+
+        String s = "cat /home/jhe/Patch0.json | ssh -l" + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost + "build Patch1 -p patchFile.json=";
+
+        System.out.println("getJenkinsCmd, s => " + s);
+
+        tmpCmd.add("/bin/sh");
+        tmpCmd.add("-c");
+        tmpCmd.add(s);
+
+        return tmpCmd.stream().toArray(String[]::new);
+
+// TODO JHE (01.10.2020) : do not forget to put that correct again
+        /*
         List<String> cmd = Lists.newArrayList();
         cmd.add("build");
         cmd.add(jobName);
@@ -76,6 +92,8 @@ public class JenkinsSshBuildJobCmd extends JenkinsSshCommand {
         }
 
         return cmd.stream().toArray(String[]::new);
+
+        */
 
     }
 }

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshBuildJobCmd.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshBuildJobCmd.java
@@ -12,7 +12,7 @@ public class JenkinsSshBuildJobCmd extends JenkinsSshCommand {
 
     private Map<String,String> jobParameters;
 
-    private Map<String,File> fileParams;
+    private Map<String,String> fileParams;
 
     private boolean waitForJobToBeFinish;
 
@@ -25,7 +25,7 @@ public class JenkinsSshBuildJobCmd extends JenkinsSshCommand {
         this.waitForJobToBeFinish = waitForJobToBeFinish;
     }
 
-    public JenkinsSshBuildJobCmd(String jenkinsHost, String jenkinsSshPort, String jenkinsSshUser, String jobName, Map<String,String> jobParameters ,Map<String,File> fileParams, boolean waitFoJobToStart, boolean waitForJobToBeFinish) {
+    public JenkinsSshBuildJobCmd(String jenkinsHost, String jenkinsSshPort, String jenkinsSshUser, String jobName, Map<String,String> jobParameters ,Map<String,String> fileParams, boolean waitFoJobToStart, boolean waitForJobToBeFinish) {
         super(jenkinsHost, jenkinsSshPort, jenkinsSshUser);
         this.jobName = jobName;
         this.jobParameters = jobParameters;
@@ -40,9 +40,16 @@ public class JenkinsSshBuildJobCmd extends JenkinsSshCommand {
     }
 
     @Override
-    protected String getFileNameParameter() {
+    protected String getFileParameterName() {
         if(hasFileParam()) {
-            return fileParams.get(fileParams.keySet().toArray()[0]).getName();
+            return fileParams.keySet().stream().findFirst().get();
+        }
+        return null;
+    }
+
+    private String getFileParameterValue() {
+        if(hasFileParam()) {
+            return fileParams.get(getFileParameterName());
         }
         return null;
     }
@@ -50,19 +57,18 @@ public class JenkinsSshBuildJobCmd extends JenkinsSshCommand {
     @Override
     protected String[] getJenkinsCmd() {
 
-        // TODO JHE (01.10.2020) : do not forget to put that correct again
+        // JHE (01.10.2020): in the "cat" scenario, we have to provide the command in a "single shot".
+        //                      see also : https://stackoverflow.com/questions/3776195/using-java-processbuilder-to-execute-a-piped-command
+        //                      we're encountering the same behavior, but with "cat" command
 
         if(hasFileParam()) {
             List<String> tmpCmd = Lists.newArrayList();
-
-
-            String s = "cat /home/jhe/Patch0.json | ssh -l " + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost + " build Patch1 -p patchFile.json=";
-
-            System.out.println("getJenkinsCmd, s => " + s);
-
+            String catCmd = "cat " + getFileParameterValue() + " | ssh -l " + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost + " build Patch1 -p " + getFileParameterName() + "=";
             tmpCmd.add("/bin/sh");
             tmpCmd.add("-c");
-            tmpCmd.add(s);
+            tmpCmd.add(catCmd);
+
+            //TODO JHE (01.10.2020): eventually add -w and -f options, but not sure that would work
 
             return tmpCmd.stream().toArray(String[]::new);
         }
@@ -77,13 +83,6 @@ public class JenkinsSshBuildJobCmd extends JenkinsSshCommand {
                     cmd.add("-p");
                     cmd.add(key + "=" + jobParameters.get(key));
                 }
-            }
-
-            if(hasFileParam()) {
-                String fileParamName = (String) fileParams.keySet().toArray()[0];
-                cmd.add("-p");
-                cmd.add(fileParamName + "=");
-
             }
 
             if(waitForJobToBeFinish) {

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshBuildJobCmd.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshBuildJobCmd.java
@@ -53,7 +53,7 @@ public class JenkinsSshBuildJobCmd extends JenkinsSshCommand {
         List<String> tmpCmd = Lists.newArrayList();
 
 
-        String s = "cat /home/jhe/Patch0.json | ssh -l" + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost + " build Patch1 -p patchFile.json=";
+        String s = "cat /home/jhe/Patch0.json | ssh -l " + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost + " build Patch1 -p patchFile.json=";
 
         System.out.println("getJenkinsCmd, s => " + s);
 

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshBuildJobCmd.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshBuildJobCmd.java
@@ -53,7 +53,7 @@ public class JenkinsSshBuildJobCmd extends JenkinsSshCommand {
         List<String> tmpCmd = Lists.newArrayList();
 
 
-        String s = "cat /home/jhe/Patch0.json | ssh -l" + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost + "build Patch1 -p patchFile.json=";
+        String s = "cat /home/jhe/Patch0.json | ssh -l" + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost + " build Patch1 -p patchFile.json=";
 
         System.out.println("getJenkinsCmd, s => " + s);
 

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshBuildJobCmd.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshBuildJobCmd.java
@@ -63,7 +63,7 @@ public class JenkinsSshBuildJobCmd extends JenkinsSshCommand {
 
         if(hasFileParam()) {
             List<String> tmpCmd = Lists.newArrayList();
-            String catCmd = "cat " + getFileParameterValue() + " | ssh -l " + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost + " build Patch1 -p " + getFileParameterName() + "=";
+            String catCmd = "cat " + getFileParameterValue() + " | ssh -l " + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost + " build " + jobName + " -p " + getFileParameterName() + "=";
             tmpCmd.add("/bin/sh");
             tmpCmd.add("-c");
             tmpCmd.add(catCmd);

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshBuildJobCmd.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshBuildJobCmd.java
@@ -50,50 +50,54 @@ public class JenkinsSshBuildJobCmd extends JenkinsSshCommand {
     @Override
     protected String[] getJenkinsCmd() {
 
-        List<String> tmpCmd = Lists.newArrayList();
-
-
-        String s = "cat /home/jhe/Patch0.json | ssh -l " + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost + " build Patch1 -p patchFile.json=";
-
-        System.out.println("getJenkinsCmd, s => " + s);
-
-        tmpCmd.add("/bin/sh");
-        tmpCmd.add("-c");
-        tmpCmd.add(s);
-
-        return tmpCmd.stream().toArray(String[]::new);
-
-// TODO JHE (01.10.2020) : do not forget to put that correct again
-        /*
-        List<String> cmd = Lists.newArrayList();
-        cmd.add("build");
-        cmd.add(jobName);
-
-        if (jobParameters != null && !jobParameters.isEmpty()) {
-            for (String key : jobParameters.keySet()) {
-                cmd.add("-p");
-                cmd.add(key + "=" + jobParameters.get(key));
-            }
-        }
+        // TODO JHE (01.10.2020) : do not forget to put that correct again
 
         if(hasFileParam()) {
-            String fileParamName = (String) fileParams.keySet().toArray()[0];
-            cmd.add("-p");
-            cmd.add(fileParamName + "=");
+            List<String> tmpCmd = Lists.newArrayList();
+
+
+            String s = "cat /home/jhe/Patch0.json | ssh -l " + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost + " build Patch1 -p patchFile.json=";
+
+            System.out.println("getJenkinsCmd, s => " + s);
+
+            tmpCmd.add("/bin/sh");
+            tmpCmd.add("-c");
+            tmpCmd.add(s);
+
+            return tmpCmd.stream().toArray(String[]::new);
+        }
+        else {
+
+            List<String> cmd = Lists.newArrayList();
+            cmd.add("build");
+            cmd.add(jobName);
+
+            if (jobParameters != null && !jobParameters.isEmpty()) {
+                for (String key : jobParameters.keySet()) {
+                    cmd.add("-p");
+                    cmd.add(key + "=" + jobParameters.get(key));
+                }
+            }
+
+            if(hasFileParam()) {
+                String fileParamName = (String) fileParams.keySet().toArray()[0];
+                cmd.add("-p");
+                cmd.add(fileParamName + "=");
+
+            }
+
+            if(waitForJobToBeFinish) {
+                cmd.add("-f");
+            }
+
+            if(waitForJobToStart) {
+                cmd.add("-w");
+            }
+
+            return cmd.stream().toArray(String[]::new);
+
 
         }
-
-        if(waitForJobToBeFinish) {
-            cmd.add("-f");
-        }
-
-        if(waitForJobToStart) {
-            cmd.add("-w");
-        }
-
-        return cmd.stream().toArray(String[]::new);
-
-        */
 
     }
 }

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
@@ -91,7 +91,7 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
 
     private String[] getFirstPart() {
         if(hasFileParam()) {
-            return new String[] {"cat /home/jhe/Patch0.json |", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
+            return new String[] {"/bin/sh", "cat", "/home/jhe/Patch0.json", "|", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
         }
         else {
             return new String[]{"ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
@@ -91,6 +91,7 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
 
     private String[] getFirstPart() {
         if(hasFileParam()) {
+            // TODO JHE (01.10.2020): do not forget to set that correctly again
             //return new String[] {"cat", "/home/jhe/Patch0.json", "|", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
             System.out.println("getFirstPart() -> " + "cat /home/jhe/Patch0.json | ssh -l " + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost);
             return new String[] {"/bin/sh", "-c", "cat /home/jhe/Patch0.json | ssh -l " + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost};

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
@@ -94,7 +94,7 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
             // TODO JHE (30.09.2020) : remove this comment, debug purpose
             System.out.println("SystemUtils.IS_OS_WINDOWS = " + SystemUtils.IS_OS_WINDOWS);
             System.out.println("getFileNameParameter = " + getFileNameParameter());
-            return new String[] {"cat", "/home/jhe/Patch0.json", " | ", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
+            return new String[] {"cat", "/home/jhe/Patch0.json", "|", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
         }
         else {
             return new String[]{"ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
@@ -91,7 +91,7 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
 
     private String[] getFirstPart() {
         if(hasFileParam()) {
-            return new String[] {"/bin/sh", "cat", "/home/jhe/Patch0.json", "|", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
+            return new String[] {"/bin/sh", "-c", "cat", "/home/jhe/Patch0.json", "|", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
         }
         else {
             return new String[]{"ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
@@ -91,7 +91,7 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
 
     private String[] getFirstPart() {
         if(hasFileParam()) {
-            return new String[] {"cat ", getFileNameParameter(), " | ", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
+            return new String[] {"cat ", getFileNameParameter(), " | ssh ", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
         }
         else {
             return new String[]{"ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
@@ -76,8 +76,13 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
 
     @Override
     protected String[] getParameterAsArray() {
+        //TODO JHE (01.10.2020) : put this correctly again after testing
+        /*
         String[] parameter = Stream.concat(Arrays.stream(getFirstPart()), Arrays.stream(getJenkinsCmd()))
                 .toArray(String[]::new);
+
+         */
+        String[] parameter = Arrays.stream(getJenkinsCmd()).toArray(String[]::new);
         return parameter;
     }
 
@@ -93,8 +98,10 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
         if(hasFileParam()) {
             // TODO JHE (01.10.2020): do not forget to set that correctly again
             //return new String[] {"cat", "/home/jhe/Patch0.json", "|", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
-            System.out.println("getFirstPart() -> " + "cat /home/jhe/Patch0.json | ssh -l " + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost);
-            return new String[] {"/bin/sh", "-c", "cat /home/jhe/Patch0.json | ssh -l " + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost};
+
+           // System.out.println("getFirstPart() -> " + "cat /home/jhe/Patch0.json | ssh -l " + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost);
+            //return new String[] {"/bin/sh", "-c", "cat /home/jhe/Patch0.json | ssh -l " + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost};
+            return new String[]{};
         }
         else {
             return new String[]{"ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
@@ -91,7 +91,9 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
 
     private String[] getFirstPart() {
         if(hasFileParam()) {
-            return new String[] {"cat ", getFileNameParameter(), " | ssh ", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
+            // TODO JHE (30.09.2020) : remove this comment, debug purpose
+            System.out.println("getFileNameParameter = " + getFileNameParameter());
+            return new String[] {"cat " + getFileNameParameter(), " | ssh ", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
         }
         else {
             return new String[]{"ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
@@ -91,10 +91,7 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
 
     private String[] getFirstPart() {
         if(hasFileParam()) {
-            // TODO JHE (30.09.2020) : remove this comment, debug purpose
-            System.out.println("SystemUtils.IS_OS_WINDOWS = " + SystemUtils.IS_OS_WINDOWS);
-            System.out.println("getFileNameParameter = " + getFileNameParameter());
-            return new String[] {"cat", "/home/jhe/Patch0.json", "|", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
+            return new String[] {"cat /home/jhe/Patch0.json |", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
         }
         else {
             return new String[]{"ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
@@ -82,7 +82,13 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
                 .toArray(String[]::new);
 
          */
-        String[] parameter = Arrays.stream(getJenkinsCmd()).toArray(String[]::new);
+        String[] parameter;
+        if(hasFileParam()) {
+            parameter = Arrays.stream(getJenkinsCmd()).toArray(String[]::new);
+        }
+        else {
+            parameter = Stream.concat(Arrays.stream(getFirstPart()), Arrays.stream(getJenkinsCmd())).toArray(String[]::new);
+        }
         return parameter;
     }
 

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
@@ -92,6 +92,7 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
     private String[] getFirstPart() {
         if(hasFileParam()) {
             // TODO JHE (30.09.2020) : remove this comment, debug purpose
+            System.out.println("SystemUtils.IS_OS_WINDOWS = " + SystemUtils.IS_OS_WINDOWS);
             System.out.println("getFileNameParameter = " + getFileNameParameter());
             return new String[] {"cat " + getFileNameParameter(), " | ssh ", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
         }

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
@@ -94,7 +94,7 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
             // TODO JHE (30.09.2020) : remove this comment, debug purpose
             System.out.println("SystemUtils.IS_OS_WINDOWS = " + SystemUtils.IS_OS_WINDOWS);
             System.out.println("getFileNameParameter = " + getFileNameParameter());
-            return new String[] {"cat", getFileNameParameter(), " | ", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
+            return new String[] {"cat", "/home/jhe/Patch0.json", " | ", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
         }
         else {
             return new String[]{"ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
@@ -94,7 +94,7 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
             // TODO JHE (30.09.2020) : remove this comment, debug purpose
             System.out.println("SystemUtils.IS_OS_WINDOWS = " + SystemUtils.IS_OS_WINDOWS);
             System.out.println("getFileNameParameter = " + getFileNameParameter());
-            return new String[] {"cat " + getFileNameParameter(), " | ssh ", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
+            return new String[] {"toto", getFileNameParameter(), " | ", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
         }
         else {
             return new String[]{"ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
@@ -66,7 +66,7 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
 
         String[] processBuilderParm;
         if (SystemUtils.IS_OS_WINDOWS && !noSystemCheck) {
-            processBuilderParm = new String[] { "bash.exe", "-c", "-s", "ssh " +  getParameterSpaceSeperated() };
+            processBuilderParm = new String[] { "bash.exe", "-c", "-s", " " + getParameterSpaceSeperated() };
         } else {
             processBuilderParm = getParameterAsArray();
         }
@@ -94,7 +94,7 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
             // TODO JHE (30.09.2020) : remove this comment, debug purpose
             System.out.println("SystemUtils.IS_OS_WINDOWS = " + SystemUtils.IS_OS_WINDOWS);
             System.out.println("getFileNameParameter = " + getFileNameParameter());
-            return new String[] {"toto", getFileNameParameter(), " | ", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
+            return new String[] {"cat", getFileNameParameter(), " | ", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
         }
         else {
             return new String[]{"ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
@@ -91,7 +91,7 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
 
     private String[] getFirstPart() {
         if(hasFileParam()) {
-            return new String[] {"/bin/sh", "-c", "cat", "/home/jhe/Patch0.json", "|", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
+            return new String[] {"/bin/sh&", "cat", "/home/jhe/Patch0.json", "|", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
         }
         else {
             return new String[]{"ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshCommand.java
@@ -91,7 +91,9 @@ public abstract class JenkinsSshCommand extends CommandBaseImpl {
 
     private String[] getFirstPart() {
         if(hasFileParam()) {
-            return new String[] {"/bin/sh&", "cat", "/home/jhe/Patch0.json", "|", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
+            //return new String[] {"cat", "/home/jhe/Patch0.json", "|", "ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};
+            System.out.println("getFirstPart() -> " + "cat /home/jhe/Patch0.json | ssh -l " + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost);
+            return new String[] {"/bin/sh", "-c", "cat /home/jhe/Patch0.json | ssh -l " + jenkinsSshUser + " -p " + jenkinsSshPort + " " + jenkinsHost};
         }
         else {
             return new String[]{"ssh", "-l", jenkinsSshUser, "-p", jenkinsSshPort, jenkinsHost};

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshStopBuildCmd.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/JenkinsSshStopBuildCmd.java
@@ -25,7 +25,7 @@ public class JenkinsSshStopBuildCmd extends JenkinsSshCommand {
     }
 
     @Override
-    protected String getFileNameParameter() {
+    protected String getFileParameterName() {
         return null;
     }
 

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/SimplePatchContainerBean.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/SimplePatchContainerBean.java
@@ -408,6 +408,12 @@ public class SimplePatchContainerBean implements PatchService, PatchOpService {
 	@Override
 	public void startInstallPipeline(String target) { jenkinsClient.startInstallPipeline(target); }
 
+	@Override
+	public void startJenkinsBuildPipeline(String patchNumber) {
+		Patch patch = repo.findById(patchNumber);
+		jenkinsClient.startProdPatchPipeline(patch);
+	}
+
 	private boolean containsObject(String patchNumber, String objectName) {
 		Patch patch = findById(patchNumber);
 		for(MavenArtifact ma : patch.getMavenArtifacts()) {
@@ -438,7 +444,7 @@ public class SimplePatchContainerBean implements PatchService, PatchOpService {
 	}
 
 	@Override
-	public void startJenkinsJob(String jobName, Map<JenkinsParameterType, Map> params) {
+	public void startJenkinsJob(String jobName, Map<String,String> params) {
 		jenkinsClient.startJenkinsJob(jobName,params);
 	}
 }

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/SimplePatchContainerBean.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/SimplePatchContainerBean.java
@@ -438,7 +438,7 @@ public class SimplePatchContainerBean implements PatchService, PatchOpService {
 	}
 
 	@Override
-	public void startJenkinsJob(String jobName, Map<String, String> jobParams) {
-		jenkinsClient.startJenkinsJob(jobName,jobParams);
+	public void startJenkinsJob(String jobName, Map<JenkinsParameterType, Map> params) {
+		jenkinsClient.startJenkinsJob(jobName,params);
 	}
 }

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClient.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClient.java
@@ -1,6 +1,5 @@
 package com.apgsga.microservice.patch.core.impl.jenkins;
 
-import com.apgsga.microservice.patch.api.JenkinsParameterType;
 import com.apgsga.microservice.patch.api.Patch;
 
 import java.util.Map;
@@ -20,5 +19,6 @@ public interface JenkinsClient {
 	void startInstallPipeline(String target);
 
 	void startJenkinsJob(String jobName);
-	void startJenkinsJob(String jobName, Map<JenkinsParameterType,Map> params);
+
+	void startJenkinsJob(String jobName, Map<String,String> params);
 }

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClient.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClient.java
@@ -1,8 +1,9 @@
 package com.apgsga.microservice.patch.core.impl.jenkins;
 
-import java.util.Map;
-
+import com.apgsga.microservice.patch.api.JenkinsParameterType;
 import com.apgsga.microservice.patch.api.Patch;
+
+import java.util.Map;
 
 public interface JenkinsClient {
 
@@ -19,6 +20,5 @@ public interface JenkinsClient {
 	void startInstallPipeline(String target);
 
 	void startJenkinsJob(String jobName);
-
-	void startJenkinsJob(String jobName, Map<String,String> jobParams);
+	void startJenkinsJob(String jobName, Map<JenkinsParameterType,Map> params);
 }

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClientImpl.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClientImpl.java
@@ -1,5 +1,6 @@
 package com.apgsga.microservice.patch.core.impl.jenkins;
 
+import com.apgsga.microservice.patch.api.JenkinsParameterType;
 import com.apgsga.microservice.patch.api.Patch;
 import com.apgsga.microservice.patch.core.commands.CommandRunner;
 import com.apgsga.microservice.patch.core.commands.ProcessBuilderCmdRunnerFactory;
@@ -223,8 +224,8 @@ public class JenkinsClientImpl implements JenkinsClient {
 	}
 
 	@Override
-	public void startJenkinsJob(String jobName, Map<String, String> jobParams) {
-		JenkinsSshCommand cmd = JenkinsSshCommand.createJenkinsSshBuildJobAndReturnImmediatelyCmd(jenkinsUrl, jenkinsSshPort, jenkinsSshUser, jobName, jobParams, null);
+	public void startJenkinsJob(String jobName, Map<JenkinsParameterType,Map> params) {
+		JenkinsSshCommand cmd = JenkinsSshCommand.createJenkinsSshBuildJobAndReturnImmediatelyCmd(jenkinsUrl, jenkinsSshPort, jenkinsSshUser, jobName, params.get(JenkinsParameterType.STRING_PARAM), params.get(JenkinsParameterType.FILE_PARAM));
 		cmdRunner.run(cmd);
 	}
 }

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClientImpl.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClientImpl.java
@@ -71,8 +71,8 @@ public class JenkinsClientImpl implements JenkinsClient {
 			String patchName = PATCH_CONS + patch.getPatchNummer();
 			String jobName = patchName + jobSuffix;
 			File patchFile = new File(dbLocation.getFile(), patchName + JSON_CONS);
-			Map<String,File> fileParams = Maps.newHashMap();
-			fileParams.put("patchJson",patchFile);
+			Map<String,String> fileParams = Maps.newHashMap();
+			fileParams.put("patchJson",patchFile.getAbsolutePath());
 
 			if(jobSuffix.equalsIgnoreCase("ondemand")) {
 				JenkinsSshCommand onDemandCmd = JenkinsSshCommand.createJenkinsSshBuildJobAndReturnImmediatelyCmd(jenkinsUrl, jenkinsSshPort, jenkinsSshUser, jobName, null, fileParams);

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClientImpl.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClientImpl.java
@@ -71,7 +71,7 @@ public class JenkinsClientImpl implements JenkinsClient {
 			String jobName = patchName + jobSuffix;
 			File patchFile = new File(dbLocation.getFile(), patchName + JSON_CONS);
 			Map<String,String> fileParams = Maps.newHashMap();
-			fileParams.put("patchJson",patchFile.getAbsolutePath());
+			fileParams.put("patchFile.json",patchFile.getAbsolutePath());
 
 			if(jobSuffix.equalsIgnoreCase("ondemand")) {
 				JenkinsSshCommand onDemandCmd = JenkinsSshCommand.createJenkinsSshBuildJobAndReturnImmediatelyCmd(jenkinsUrl, jenkinsSshPort, jenkinsSshUser, jobName, null, fileParams);

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClientImpl.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClientImpl.java
@@ -1,6 +1,5 @@
 package com.apgsga.microservice.patch.core.impl.jenkins;
 
-import com.apgsga.microservice.patch.api.JenkinsParameterType;
 import com.apgsga.microservice.patch.api.Patch;
 import com.apgsga.microservice.patch.core.commands.CommandRunner;
 import com.apgsga.microservice.patch.core.commands.ProcessBuilderCmdRunnerFactory;
@@ -224,8 +223,8 @@ public class JenkinsClientImpl implements JenkinsClient {
 	}
 
 	@Override
-	public void startJenkinsJob(String jobName, Map<JenkinsParameterType,Map> params) {
-		JenkinsSshCommand cmd = JenkinsSshCommand.createJenkinsSshBuildJobAndReturnImmediatelyCmd(jenkinsUrl, jenkinsSshPort, jenkinsSshUser, jobName, params.get(JenkinsParameterType.STRING_PARAM), params.get(JenkinsParameterType.FILE_PARAM));
+	public void startJenkinsJob(String jobName, Map<String,String> params) {
+		JenkinsSshCommand cmd = JenkinsSshCommand.createJenkinsSshBuildJobAndReturnImmediatelyCmd(jenkinsUrl, jenkinsSshPort, jenkinsSshUser, jobName, params,null);
 		cmdRunner.run(cmd);
 	}
 }

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsMockClient.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsMockClient.java
@@ -1,13 +1,10 @@
 package com.apgsga.microservice.patch.core.impl.jenkins;
 
-import java.io.File;
-import java.util.Map;
-
-import com.apgsga.microservice.patch.api.JenkinsParameterType;
+import com.apgsga.microservice.patch.api.Patch;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import com.apgsga.microservice.patch.api.Patch;
+import java.util.Map;
 
 public class JenkinsMockClient implements JenkinsClient {
 
@@ -52,20 +49,12 @@ public class JenkinsMockClient implements JenkinsClient {
 	}
 
 	@Override
-	public void startJenkinsJob(String jobName, Map<JenkinsParameterType, Map> params) {
+	public void startJenkinsJob(String jobName, Map<String,String> params) {
 		LOGGER.info("startJenkinsjob, jobName=" + jobName);
-		Map<String,String> stringParam = params.get(JenkinsParameterType.STRING_PARAM);
-		Map<String,String> fileParam = params.get(JenkinsParameterType.FILE_PARAM);
-		if(stringParam != null && !stringParam.isEmpty()) {
-			stringParam.keySet().forEach(k -> {
-				LOGGER.info("Job Param key = " + k + ", value = " + stringParam.get(k));
+		if(params != null && !params.isEmpty()) {
+			params.keySet().forEach(k -> {
+				LOGGER.info("Job Param key = " + k + ", value = " + params.get(k));
 			});
 		}
-		if(fileParam != null && !fileParam.isEmpty()) {
-			fileParam.keySet().forEach(k -> {
-				LOGGER.info("File Param key = " + k + ", value (as filePath) = " + fileParam.get(k));
-			});
-		}
-
 	}
 }

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsMockClient.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsMockClient.java
@@ -1,7 +1,9 @@
 package com.apgsga.microservice.patch.core.impl.jenkins;
 
+import java.io.File;
 import java.util.Map;
 
+import com.apgsga.microservice.patch.api.JenkinsParameterType;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -50,10 +52,20 @@ public class JenkinsMockClient implements JenkinsClient {
 	}
 
 	@Override
-	public void startJenkinsJob(String jobName, Map<String, String> jobParams) {
+	public void startJenkinsJob(String jobName, Map<JenkinsParameterType, Map> params) {
 		LOGGER.info("startJenkinsjob, jobName=" + jobName);
-		jobParams.keySet().forEach(k -> {
-			LOGGER.info("Param key = " + k + ", value = " + jobParams.get(k));
-		});
+		Map<String,String> stringParam = params.get(JenkinsParameterType.STRING_PARAM);
+		Map<String,File> fileParam = params.get(JenkinsParameterType.FILE_PARAM);
+		if(stringParam != null && !stringParam.isEmpty()) {
+			stringParam.keySet().forEach(k -> {
+				LOGGER.info("Job Param key = " + k + ", value = " + stringParam.get(k));
+			});
+		}
+		if(fileParam != null && !fileParam.isEmpty()) {
+			fileParam.keySet().forEach(k -> {
+				LOGGER.info("File Param key = " + k + ", value (as filePath) = " + fileParam.get(k));
+			});
+		}
+
 	}
 }

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsMockClient.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsMockClient.java
@@ -55,7 +55,7 @@ public class JenkinsMockClient implements JenkinsClient {
 	public void startJenkinsJob(String jobName, Map<JenkinsParameterType, Map> params) {
 		LOGGER.info("startJenkinsjob, jobName=" + jobName);
 		Map<String,String> stringParam = params.get(JenkinsParameterType.STRING_PARAM);
-		Map<String,File> fileParam = params.get(JenkinsParameterType.FILE_PARAM);
+		Map<String,String> fileParam = params.get(JenkinsParameterType.FILE_PARAM);
 		if(stringParam != null && !stringParam.isEmpty()) {
 			stringParam.keySet().forEach(k -> {
 				LOGGER.info("Job Param key = " + k + ", value = " + stringParam.get(k));

--- a/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsCliBaseTest.java
+++ b/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsCliBaseTest.java
@@ -8,7 +8,7 @@ public abstract class JenkinsCliBaseTest {
 
     public static final String JENKINS_SSH_USER = "jhe";
     public static final String JENKINS_USER_TOKEN = "1151e35f8912cbcb5754d7320b54e4264c";
-    public static final String JENKINS_HOST = "172.18.43.76";
+    public static final String JENKINS_HOST = "172.17.206.117";
     public static final String JENKINS_PORT = "8080";
     public static final String JENKINS_SSH_PORT = "53801";
     public static final String JENKINS_URL = "http://" + JENKINS_HOST + ":" + JENKINS_PORT;

--- a/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsCliBaseTest.java
+++ b/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsCliBaseTest.java
@@ -7,13 +7,13 @@ import java.util.List;
 public abstract class JenkinsCliBaseTest {
 
     public static final String JENKINS_SSH_USER = "jhe";
-    public static final String JENKINS_USER_TOKEN = "1121097812220766a1129ba16a294a489e";
-    public static final String JENKINS_HOST = "192.168.26.197";
+    public static final String JENKINS_USER_TOKEN = "1151e35f8912cbcb5754d7320b54e4264c";
+    public static final String JENKINS_HOST = "172.18.43.76";
     public static final String JENKINS_PORT = "8080";
     public static final String JENKINS_SSH_PORT = "53801";
     public static final String JENKINS_URL = "http://" + JENKINS_HOST + ":" + JENKINS_PORT;
     public static final String JOB_NAME_WITHOUT_FILE_PARAM = "PatchBuilder";
-    public static final String JOB_NAME_WITH_FILE_PARAM = "BuildPipelineTest";
+    public static final String JOB_NAME_WITH_FILE_PARAM = "Patch1";
     public static List<String> SSH_CMD = Lists.newArrayList("ssh");
     public static List<String> CURL_CMD = Lists.newArrayList("curl");
 }

--- a/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
+++ b/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
@@ -70,6 +70,7 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
+    @Ignore
     public void testJenkinsSshBuildJobWithParameterCmdAndWaitForStart() {
         Map<String,String> params = Maps.newHashMap();
         params.put("patchnumber","2222");
@@ -81,7 +82,6 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
-    @Ignore
     public void testJenkinsSshBuildJobWithFileParameterCmdWithoutWaiting() {
         Map<String, File> fileParams = Maps.newHashMap();
         fileParams.put("patchFile.json",new File("src/test/resources/Patch5401.json"));

--- a/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
+++ b/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
@@ -70,6 +70,7 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
+    @Ignore
     public void testJenkinsSshBuildJobWithParameterCmdAndWaitForStart() {
         Map<String,String> params = Maps.newHashMap();
         params.put("patchnumber","2222");
@@ -81,10 +82,9 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
-    @Ignore
     public void testJenkinsSshBuildJobWithFileParameterCmdWithoutWaiting() {
-        Map<String, File> fileParams = Maps.newHashMap();
-        fileParams.put("patchFile.json",new File("src/test/resources/Patch5401.json"));
+        Map<String, String> fileParams = Maps.newHashMap();
+        fileParams.put("patchFile.json","src/test/resources/Patch5401.json");
         JenkinsSshCommand jenkinsSshCommand = JenkinsSshCommand.createJenkinsSshBuildJobAndReturnImmediatelyCmd(JENKINS_HOST,JENKINS_SSH_PORT,JENKINS_SSH_USER,JOB_NAME_WITH_FILE_PARAM,null,fileParams);
         ProcessBuilderCmdRunnerFactory runnerFactory = new ProcessBuilderCmdRunnerFactory();
         CommandRunner runner = runnerFactory.create();

--- a/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
+++ b/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
@@ -81,6 +81,7 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
+    @Ignore
     public void testJenkinsSshBuildJobWithFileParameterCmdWithoutWaiting() {
         Map<String, File> fileParams = Maps.newHashMap();
         fileParams.put("patchFile.json",new File("src/test/resources/Patch5401.json"));

--- a/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
+++ b/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
@@ -70,7 +70,6 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
-    @Ignore
     public void testJenkinsSshBuildJobWithParameterCmdAndWaitForStart() {
         Map<String,String> params = Maps.newHashMap();
         params.put("patchnumber","2222");
@@ -82,6 +81,7 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
+    @Ignore
     public void testJenkinsSshBuildJobWithFileParameterCmdWithoutWaiting() {
         Map<String, File> fileParams = Maps.newHashMap();
         fileParams.put("patchFile.json",new File("src/test/resources/Patch5401.json"));

--- a/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
+++ b/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
@@ -70,7 +70,6 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
-    @Ignore
     public void testJenkinsSshBuildJobWithParameterCmdAndWaitForStart() {
         Map<String,String> params = Maps.newHashMap();
         params.put("patchnumber","2222");

--- a/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
+++ b/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
@@ -8,13 +8,15 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 
-@Ignore
+//@Ignore
 public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
 
     @Test
+    @Ignore
     public void testJenkinsSshBuildCommandWithoutWaiting() {
         JenkinsSshCommand jenkinsSshCommand = JenkinsSshCommand.createJenkinsSshBuildJobAndReturnImmediatelyCmd(JENKINS_HOST,JENKINS_SSH_PORT, JENKINS_SSH_USER, JOB_NAME_WITHOUT_FILE_PARAM);
         ProcessBuilderCmdRunnerFactory runnerFactory = new ProcessBuilderCmdRunnerFactory();
@@ -24,6 +26,7 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
+    @Ignore
     public void testJenkinsSshBuildWithParameterCommandWithoutWaiting() {
         Map<String,String> params = Maps.newHashMap();
         params.put("patchnumber","2222");
@@ -35,6 +38,7 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
+    @Ignore
     public void testJenkinsSshBuildCommandWithWaiting() {
         JenkinsSshCommand jenkinsSshCommand = JenkinsSshCommand.createJenkinsSshBuildJobAndWaitForCompleteCmd(JENKINS_HOST,JENKINS_SSH_PORT, JENKINS_SSH_USER, JOB_NAME_WITHOUT_FILE_PARAM);
         ProcessBuilderCmdRunnerFactory runnerFactory = new ProcessBuilderCmdRunnerFactory();
@@ -44,6 +48,7 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
+    @Ignore
     public void testJenkinsSshBuildWithParameterCommandWithWaiting() {
         Map<String,String> params = Maps.newHashMap();
         params.put("patchnumber","2222");
@@ -55,6 +60,7 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
+    @Ignore
     public void testJenkinsSshBuildJobCmdAndWaitForStart() {
         JenkinsSshCommand jenkinsSshCommand = JenkinsSshCommand.createJenkinsSshBuildJobAndWaitForStartCmd(JENKINS_HOST,JENKINS_SSH_PORT, JENKINS_SSH_USER, JOB_NAME_WITHOUT_FILE_PARAM);
         ProcessBuilderCmdRunnerFactory runnerFactory = new ProcessBuilderCmdRunnerFactory();
@@ -64,6 +70,7 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
+    @Ignore
     public void testJenkinsSshBuildJobWithParameterCmdAndWaitForStart() {
         Map<String,String> params = Maps.newHashMap();
         params.put("patchnumber","2222");
@@ -73,4 +80,20 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
         List<String> result = runner.run(jenkinsSshCommand);
         Assert.assertTrue("Returned message should contain SUCCESS",result.stream().anyMatch(c -> {return c.contains("Started " + JOB_NAME_WITHOUT_FILE_PARAM + " #");}));
     }
+
+    @Test
+    public void testJenkinsSshBuildJobWithFileParameterCmdWithoutWaiting() {
+        Map<String, File> fileParams = Maps.newHashMap();
+        fileParams.put("patchFile.json",new File("src/test/resources/Patch5401.json"));
+        JenkinsSshCommand jenkinsSshCommand = JenkinsSshCommand.createJenkinsSshBuildJobAndReturnImmediatelyCmd(JENKINS_HOST,JENKINS_SSH_PORT,JENKINS_SSH_USER,JOB_NAME_WITH_FILE_PARAM,null,fileParams);
+        ProcessBuilderCmdRunnerFactory runnerFactory = new ProcessBuilderCmdRunnerFactory();
+        CommandRunner runner = runnerFactory.create();
+        List<String> result = runner.run(jenkinsSshCommand);
+        result.forEach(s -> {
+            System.out.println(s);
+        });
+        System.out.println("DONE");
+    }
+
+
 }

--- a/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
+++ b/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
@@ -82,6 +82,7 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
+    @Ignore
     public void testJenkinsSshBuildJobWithFileParameterCmdWithoutWaiting() {
         Map<String, String> fileParams = Maps.newHashMap();
         fileParams.put("patchFile.json","src/test/resources/Patch5401.json");

--- a/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
+++ b/apg-patch-service-core/src/test/java/com/apgsga/microservice/patch/core/commands/jenkins/ssh/test/JenkinsSshCommandsTest.java
@@ -1,22 +1,20 @@
 package com.apgsga.microservice.patch.core.commands.jenkins.ssh.test;
 
-import com.apgsga.microservice.patch.core.commands.ProcessBuilderCmdRunnerFactory;
 import com.apgsga.microservice.patch.core.commands.CommandRunner;
+import com.apgsga.microservice.patch.core.commands.ProcessBuilderCmdRunnerFactory;
 import com.apgsga.microservice.patch.core.commands.jenkins.ssh.JenkinsSshCommand;
 import com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.io.File;
 import java.util.List;
 import java.util.Map;
 
-//@Ignore
+@Ignore
 public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
 
     @Test
-    @Ignore
     public void testJenkinsSshBuildCommandWithoutWaiting() {
         JenkinsSshCommand jenkinsSshCommand = JenkinsSshCommand.createJenkinsSshBuildJobAndReturnImmediatelyCmd(JENKINS_HOST,JENKINS_SSH_PORT, JENKINS_SSH_USER, JOB_NAME_WITHOUT_FILE_PARAM);
         ProcessBuilderCmdRunnerFactory runnerFactory = new ProcessBuilderCmdRunnerFactory();
@@ -26,7 +24,6 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
-    @Ignore
     public void testJenkinsSshBuildWithParameterCommandWithoutWaiting() {
         Map<String,String> params = Maps.newHashMap();
         params.put("patchnumber","2222");
@@ -38,7 +35,6 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
-    @Ignore
     public void testJenkinsSshBuildCommandWithWaiting() {
         JenkinsSshCommand jenkinsSshCommand = JenkinsSshCommand.createJenkinsSshBuildJobAndWaitForCompleteCmd(JENKINS_HOST,JENKINS_SSH_PORT, JENKINS_SSH_USER, JOB_NAME_WITHOUT_FILE_PARAM);
         ProcessBuilderCmdRunnerFactory runnerFactory = new ProcessBuilderCmdRunnerFactory();
@@ -48,7 +44,6 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
-    @Ignore
     public void testJenkinsSshBuildWithParameterCommandWithWaiting() {
         Map<String,String> params = Maps.newHashMap();
         params.put("patchnumber","2222");
@@ -60,7 +55,6 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
-    @Ignore
     public void testJenkinsSshBuildJobCmdAndWaitForStart() {
         JenkinsSshCommand jenkinsSshCommand = JenkinsSshCommand.createJenkinsSshBuildJobAndWaitForStartCmd(JENKINS_HOST,JENKINS_SSH_PORT, JENKINS_SSH_USER, JOB_NAME_WITHOUT_FILE_PARAM);
         ProcessBuilderCmdRunnerFactory runnerFactory = new ProcessBuilderCmdRunnerFactory();
@@ -70,7 +64,6 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
-    @Ignore
     public void testJenkinsSshBuildJobWithParameterCmdAndWaitForStart() {
         Map<String,String> params = Maps.newHashMap();
         params.put("patchnumber","2222");
@@ -82,7 +75,6 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
     }
 
     @Test
-    @Ignore
     public void testJenkinsSshBuildJobWithFileParameterCmdWithoutWaiting() {
         Map<String, String> fileParams = Maps.newHashMap();
         fileParams.put("patchFile.json","src/test/resources/Patch5401.json");
@@ -95,6 +87,4 @@ public class JenkinsSshCommandsTest extends JenkinsCliBaseTest {
         });
         System.out.println("DONE");
     }
-
-
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/PatchOpServiceController.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/PatchOpServiceController.java
@@ -10,7 +10,6 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.File;
 import java.util.List;
 import java.util.Map;
 

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/PatchOpServiceController.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/PatchOpServiceController.java
@@ -171,6 +171,13 @@ public class PatchOpServiceController implements PatchOpService, PatchPersistenc
 		patchService.startInstallPipeline(target);
 	}
 
+	@RequestMapping(value = "/startJenkinsBuildPipeline/{patchNumber}", method = RequestMethod.POST)
+	@ResponseStatus(HttpStatus.OK)
+	@Override
+	public void startJenkinsBuildPipeline(@PathVariable("patchNumber") String patchNumber) {
+		patchService.startJenkinsBuildPipeline(patchNumber);
+	}
+
 	@RequestMapping(value = "/copyPatchFiles", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.OK)
 	@Override
@@ -202,7 +209,7 @@ public class PatchOpServiceController implements PatchOpService, PatchPersistenc
 	@RequestMapping(value = "/startJenkinsJobWithParam/{jobName}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.OK)
 	@Override
-	public void startJenkinsJob(@PathVariable String jobName, @RequestBody Map<JenkinsParameterType, Map> params) {
+	public void startJenkinsJob(@PathVariable String jobName, @RequestBody Map<String,String> params) {
 		patchService.startJenkinsJob(jobName,params);
 	}
 }

--- a/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/PatchOpServiceController.java
+++ b/apg-patch-service-server/src/main/java/com/apgsga/microservice/patch/server/PatchOpServiceController.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 
@@ -201,7 +202,7 @@ public class PatchOpServiceController implements PatchOpService, PatchPersistenc
 	@RequestMapping(value = "/startJenkinsJobWithParam/{jobName}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.OK)
 	@Override
-	public void startJenkinsJob(@PathVariable String jobName, @RequestBody Map<String, String> jobParams) {
-		patchService.startJenkinsJob(jobName,jobParams);
+	public void startJenkinsJob(@PathVariable String jobName, @RequestBody Map<JenkinsParameterType, Map> params) {
+		patchService.startJenkinsJob(jobName,params);
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ project.ext {
 allprojects  {
 	apply plugin: 'maven'
 	group = 'com.apgsga.patchframework'
-	version  = '2.3.DEVD1'
+	version  = '2.4.DEVD1'
 }
 subprojects {
 	apply plugin: 'java'


### PR DESCRIPTION
In scope of IT-36392, we need to be able to start a Job with a file as parameter. This was so far not supported by apscli. I had to refactor a bit our SSHJenkinsCommand part, because of a crazy problem with Linux pipe and Java ProcessBuilder.
The problem was similar to this one, but with "cat" command: https://stackoverflow.com/questions/3776195/using-java-processbuilder-to-execute-a-piped-command

Note that the current implementation doesn't support to sart a job which would have both string and file parameters, but I don't believe this is a scenario we have to support now.

Ideally, I would like to quickly merge this one.