### PR TITLE
IT-36392 / stageMapping saved within Patch object

### DIFF
--- a/apg-patch-service-api/src/main/java/com/apgsga/microservice/patch/api/Patch.java
+++ b/apg-patch-service-api/src/main/java/com/apgsga/microservice/patch/api/Patch.java
@@ -40,6 +40,8 @@ public class Patch extends AbstractTransientEntity {
 
     public static final String CURRENT_PIPELINE_TASK = "currentPipelineTask";
 
+    public static final String STAGES_MAPPING = "stagesMapping";
+
 
     private String patchNummer;
     private String dbPatchBranch;
@@ -58,6 +60,7 @@ public class Patch extends AbstractTransientEntity {
     private String currentTarget;
     private String currentPipelineTask;
     private String logText;
+    private List<String> stagesMapping;
 
     public Patch() {
         super();
@@ -86,7 +89,6 @@ public class Patch extends AbstractTransientEntity {
         this.dbPatchBranch = dbPatchBranch;
         firePropertyChangeAndMarkDirty(DB_PATCH_BRANCH, oldValue, dbPatchBranch);
     }
-
 
     public String getProdBranch() {
         return prodBranch;
@@ -249,6 +251,16 @@ public class Patch extends AbstractTransientEntity {
         final Object oldValue = this.currentPipelineTask;
         this.currentPipelineTask = currentPipelineTask;
         firePropertyChange(CURRENT_PIPELINE_TASK, oldValue, currentPipelineTask);
+    }
+
+    public List<String> getStagesMapping() {
+        return stagesMapping;
+    }
+
+    public void setStagesMapping(List<String> stagesMapping) {
+        final Object oldValue = this.stagesMapping;
+        this.stagesMapping = stagesMapping;
+        firePropertyChange(STAGES_MAPPING, oldValue, stagesMapping);
     }
 
     public Service getService(String serviceName) {

--- a/apg-patch-service-client/src/test/java/com/apgsga/microservice/patch/client/MicroServicePatchClientTest.java
+++ b/apg-patch-service-client/src/test/java/com/apgsga/microservice/patch/client/MicroServicePatchClientTest.java
@@ -214,12 +214,25 @@ public class MicroServicePatchClientTest {
 	}
 
 	@Test
-	public void listOnDemandTargets() {
+	public void testListOnDemandTargets() {
 		List<String> onDemandTargets = patchClient.listOnDemandTargets();
 		assertEquals(4,onDemandTargets.size());
 		assertTrue(onDemandTargets.contains("DEV-CHEI212"));
 		assertTrue(onDemandTargets.contains("DEV-CHEI211"));
 		assertTrue(onDemandTargets.contains("DEV-CM"));
 		assertTrue(onDemandTargets.contains("DEV-JHE"));
+	}
+
+	@Test
+	public void testStageMappingsWithinPatch() {
+		Patch patch = new Patch();
+		patch.setPatchNummer("2222");
+		patchClient.save(patch);
+		Patch result = patchClient.findById("2222");
+		List<String> stagesMapping = result.getStagesMapping();
+		stagesMapping.get(0).equals("Entwicklung");
+		stagesMapping.get(1).equals("Informatiktest");
+		stagesMapping.get(2).equals("Anwendertest");
+		stagesMapping.get(3).equals("Produktion");
 	}
 }

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/SimplePatchContainerBean.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/SimplePatchContainerBean.java
@@ -157,6 +157,7 @@ public class SimplePatchContainerBean implements PatchService, PatchOpService {
 
 	private void preProcessSave(Patch patch) {
 		if (!repo.patchExists(patch.getPatchNummer())) {
+			patch.setStagesMapping(getStageMappings());
 			createBranchForDbModules(patch);
 			jenkinsClient.createPatchPipelines(patch);
 		}
@@ -166,6 +167,15 @@ public class SimplePatchContainerBean implements PatchService, PatchOpService {
 					.forEach(art -> addModuleName(art, service.getMicroServiceBranch()));
 		}
 
+	}
+
+	private List<String> getStageMappings() {
+		List<String> mapping = Lists.newArrayList();
+		List<StageMapping> stageMappings = metaInfoRepo.stageMappings().getStageMappings();
+		stageMappings.forEach(stage -> {
+			mapping.add(stage.getName());
+		});
+		return mapping;
 	}
 
 	private MavenArtifact addModuleName(MavenArtifact art, String cvsBranch) {

--- a/apg-patch-service-server/src/test/java/com/apgsga/microservice/patch/core/MicroServicePatchServerTest.java
+++ b/apg-patch-service-server/src/test/java/com/apgsga/microservice/patch/core/MicroServicePatchServerTest.java
@@ -267,6 +267,19 @@ public class MicroServicePatchServerTest {
 	}
 
 	@Test
+	public void testStageMappingsWithinPatch() {
+		Patch patch = new Patch();
+		patch.setPatchNummer("2222");
+		patchService.save(patch);
+		Patch result = patchService.findById("2222");
+		List<String> stagesMapping = result.getStagesMapping();
+		stagesMapping.get(0).equals("Entwicklung");
+		stagesMapping.get(1).equals("Informatiktest");
+		stagesMapping.get(2).equals("Anwendertest");
+		stagesMapping.get(3).equals("Produktion");
+	}
+
+	@Test
 	// JHE (17.08.2020) : Ignoring it since it requires DB pre-requisite to work
 	//					  Also the following properties have to be correctly defined into application-test.properties
 	//							rdbms.oracle.url

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ project.ext {
 allprojects  {
 	apply plugin: 'maven'
 	group = 'com.apgsga.patchframework'
-	version  = '2.4.DEVD1'
+	version  = '2.5.DEVD1'
 }
 subprojects {
 	apply plugin: 'java'


### PR DESCRIPTION
@chhex, @apgsga-uge  : I'll probably merge this one quickly. I believe the important point to noticed is within SimplePatchContainerBean, where we save the info only when the patch does not exist. That means, we cannot change the stageMappings for an existing Patch, which I believe makes sense ... but yep, we could discuss it.