### PR TITLE
TaskStartOnClonePipeline started with GenericJobBuilder

### DIFF
--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClientImpl.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClientImpl.java
@@ -117,7 +117,16 @@ public class JenkinsClientImpl implements JenkinsClient {
 
 	@Override
 	public void startOnClonePipeline(OnCloneParameters parameters) {
-		threadExecutor.execute(TaskStartOnClonePipeline.create(jenkinsUrl,jenkinsSshPort,jenkinsSshUser,preprocessor,cmdRunner,parameters));
+		TaskStartOnClonePipeline runnable = TaskStartOnClonePipeline.create()
+				.jenkinsUrl(jenkinsUrl)
+				.jenkinsSshPort(jenkinsSshPort)
+				.jenkinsSshUser(jenkinsSshUser)
+				.preprocessor(preprocessor)
+				.cmdRunner(cmdRunner)
+		        .onCloneParameter(parameters)
+				.jenkinsPipelineRepo(jenkinsPipelineRepo)
+				.jenkinsPipelineRepoBranch(jenkinsPipelineRepoBranch);
+		threadExecutor.execute(runnable);
 	}
 
 	private String formatParameterAsJsonForPipeline(Object obj) {


### PR DESCRIPTION
@apgsga-jhe 
See IT-36966:  patchserver-setup should create pre-defined onClone pipeline jobs.
Basically now the Clone Pipeline is started with the GenericJobBuilder per Target.  This way , we have all Target specific Jobs started via GenericJobBuilder with the same Naming Convention, which makes the ordering by Timestamp easy and also the filtering of Jobs per Target. 

See this as discussable proposition 

@apgsga-uge  FYI 