### PR TITLE
IT-37027 / Piper should not always create a new CVS DB Branch

### DIFF
--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/JschCommandRunner.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/commands/JschCommandRunner.java
@@ -65,6 +65,7 @@ public class JschCommandRunner implements CommandRunner {
 			if (channel.getExitStatus() > 0) {
 				LOGGER.warn("Command : " + command + " returning with exit code: " + channel.getExitStatus());
 			}
+			resultLines.add("SSHExistStatus=" + channel.getExitStatus());
 			channel.disconnect();
 		} catch (Exception e) {
 			throw ExceptionFactory.create("Exception : <%s>  running remote ssh command %s",e,

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/SimplePatchContainerBean.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/SimplePatchContainerBean.java
@@ -141,12 +141,12 @@ public class SimplePatchContainerBean implements PatchService, PatchOpService {
 	private Patch preProcessSave(Patch patch) {
 		DBPatch dbPatch = DBPatch.builder().dbPatchBranch(DB_PATCH_BRANCH_PREFIX + patch.getPatchNumber()).prodBranch(DB_PROD_BRANCH).build();
 		patch = patch.toBuilder().dbPatch(dbPatch).build();
-		if(!dbPatchBranchExist(patch)) {
-			LOGGER.warn("DB Patch Branch for patch " + patch.getPatchNumber() + " did not exist -> will now be created.");
-			createBranchForDbModules(patch);
-		}
 		if (!repo.patchExists(patch.getPatchNumber())) {
 			jenkinsClient.createPatchPipelines(patch);
+			if(!dbPatchBranchExist(patch)) {
+				LOGGER.warn("DB Patch Branch for patch " + patch.getPatchNumber() + " did not exist -> will now be created.");
+				createBranchForDbModules(patch);
+			}
 		}
 		return patch;
 	}

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/SimplePatchContainerBean.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/SimplePatchContainerBean.java
@@ -139,9 +139,9 @@ public class SimplePatchContainerBean implements PatchService, PatchOpService {
 	}
 
 	private Patch preProcessSave(Patch patch) {
-		DBPatch dbPatch = DBPatch.builder().dbPatchBranch(DB_PATCH_BRANCH_PREFIX + patch.getPatchNumber()).prodBranch(DB_PROD_BRANCH).build();
-		patch = patch.toBuilder().dbPatch(dbPatch).build();
 		if (!repo.patchExists(patch.getPatchNumber())) {
+			DBPatch dbPatch = DBPatch.builder().dbPatchBranch(DB_PATCH_BRANCH_PREFIX + patch.getPatchNumber()).prodBranch(DB_PROD_BRANCH).build();
+			patch = patch.toBuilder().dbPatch(dbPatch).build();
 			jenkinsClient.createPatchPipelines(patch);
 			if(!dbPatchBranchExist(patch)) {
 				LOGGER.warn("DB Patch Branch for patch " + patch.getPatchNumber() + " did not exist -> will now be created.");

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/SimplePatchContainerBean.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/SimplePatchContainerBean.java
@@ -3,9 +3,11 @@ package com.apgsga.microservice.patch.core.impl;
 import com.apgsga.artifact.query.ArtifactDependencyResolver;
 import com.apgsga.artifact.query.ArtifactManager;
 import com.apgsga.microservice.patch.api.*;
+import com.apgsga.microservice.patch.core.commands.Command;
 import com.apgsga.microservice.patch.core.commands.CommandRunner;
 import com.apgsga.microservice.patch.core.commands.CommandRunnerFactory;
 import com.apgsga.microservice.patch.core.commands.patch.vcs.PatchSshCommand;
+import com.apgsga.microservice.patch.core.commands.patch.vcs.RmTmpCheckoutFolder;
 import com.apgsga.microservice.patch.core.impl.jenkins.JenkinsClient;
 import com.apgsga.microservice.patch.exceptions.Asserts;
 import com.google.common.base.Strings;
@@ -19,6 +21,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Component;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -49,11 +52,14 @@ public class SimplePatchContainerBean implements PatchService, PatchOpService {
 	@Autowired
 	private ArtifactDependencyResolver dependencyResolver;
 
-	@Value("${db.patch.branch.prefix:Patch_}")
+	@Value("${db.patch.branch.prefix:Ms_patch_}")
 	private String DB_PATCH_BRANCH_PREFIX;
 
 	@Value("${db.prod.branch:prod}")
 	private String DB_PROD_BRANCH;
+
+	@Value("${cvs.check.for.branch.project.name:piperCheckForBranch}")
+	private String PIPER_CHECK_FOR_BRANCH_PROJECT_NAME;
 
 	public SimplePatchContainerBean() {
 		super();
@@ -133,13 +139,39 @@ public class SimplePatchContainerBean implements PatchService, PatchOpService {
 	}
 
 	private Patch preProcessSave(Patch patch) {
-		if (!repo.patchExists(patch.getPatchNumber())) {
-			DBPatch dbPatch = DBPatch.builder().dbPatchBranch(DB_PATCH_BRANCH_PREFIX + patch.getPatchNumber()).prodBranch(DB_PROD_BRANCH).build();
-			patch = patch.toBuilder().dbPatch(dbPatch).build();
+		DBPatch dbPatch = DBPatch.builder().dbPatchBranch(DB_PATCH_BRANCH_PREFIX + patch.getPatchNumber()).prodBranch(DB_PROD_BRANCH).build();
+		patch = patch.toBuilder().dbPatch(dbPatch).build();
+		if(!dbPatchBranchExist(patch)) {
+			LOGGER.warn("DB Patch Branch for patch " + patch.getPatchNumber() + " did not exist -> will now be created.");
 			createBranchForDbModules(patch);
+		}
+		if (!repo.patchExists(patch.getPatchNumber())) {
 			jenkinsClient.createPatchPipelines(patch);
 		}
 		return patch;
+	}
+
+	private boolean dbPatchBranchExist(Patch patch) {
+		final CommandRunner sshCommandRunner = sshCommandRunnerFactory.create();
+		sshCommandRunner.preProcess();
+
+		String tempCheckoutFolder = PIPER_CHECK_FOR_BRANCH_PROJECT_NAME + "_" + new SimpleDateFormat("yyyyMMddHHmmssSSS").format(new Date());
+
+		LOGGER.info("Verifying if DB Patch Branch for patch " + patch.getPatchNumber() + " exists. Checkout will be done remotely on CVS server within /home/svcCvsClient/" + tempCheckoutFolder);
+
+		Command coCvsCmd = PatchSshCommand.createCoCvsModuleToDirectoryCmd(patch.getDbPatch().getDbPatchBranch(), patch.getDbPatch().getProdBranch(), Lists.newArrayList(PIPER_CHECK_FOR_BRANCH_PROJECT_NAME), "-d " + tempCheckoutFolder);
+		List<String> result = sshCommandRunner.run(coCvsCmd);
+
+		if(!result.contains("SSHExistStatus=0")) {
+			return false;
+		}
+
+		// Delete the remote temp folder
+		RmTmpCheckoutFolder rmFolderCmd = new RmTmpCheckoutFolder(tempCheckoutFolder);
+		sshCommandRunner.run(rmFolderCmd);
+		sshCommandRunner.postProcess();
+
+		return true;
 	}
 
 	@Override

--- a/apg-patch-service-server/packaging/metaInfoDb/DbModules.json
+++ b/apg-patch-service-server/packaging/metaInfoDb/DbModules.json
@@ -50,6 +50,7 @@
 		"com.affichage.it21.resource",
 		"test.apgsga.jenkins-pipeline.it21-patch",
 		"testdbAnotherdbModule",
-		"testdbmodule"
+		"testdbmodule",
+		"piperCheckForBranch"
 	]
 }


### PR DESCRIPTION
When saving a brand new patch, we first check if the DB Branch has to be created or not. 
DB Branches will be created in advance, see also Ticket CM-328.
I also took the opportunity to rename the branch prefix from "Patch_" to "Ms_patch_" ... to ensure we will be able to differentiate between old/new branches ...

@chhex , @apgsga-uge : Ideally I would like to merge this one before restarting an installation on appl-patch.apgsga.ch