### PR TITLE
IT-37121 / verify that DB-module are merged back on prod branch when patch is in production

### DIFF
--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/PatchSetupTask.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/PatchSetupTask.java
@@ -78,7 +78,7 @@ public class PatchSetupTask implements Runnable {
             dependencyResolver.resolveDependencies(service.getArtifactsToPatch());
             for (MavenArtifact mavenArtifact : artifactsToPatch) {
                 String artifactName = am.getArtifactName(mavenArtifact.getGroupId(), mavenArtifact.getArtifactId(), mavenArtifact.getVersion());
-                Asserts.notNull(artifactName,"Missing artifactname for mavenArtifactId: %s, groupId: %s", mavenArtifact.getGroupId(), mavenArtifact.getArtifactId());
+                Asserts.notNull(artifactName,"Missing artifactname for mavenArtifactId: %s, groupId: %s", mavenArtifact.getArtifactId(), mavenArtifact.getGroupId());
                 mavenArtifact.withName(artifactName);
             }
             service.withServiceMetaData(serviceMetaData);

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/InstallDbObjectsInfos.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/InstallDbObjectsInfos.java
@@ -1,0 +1,18 @@
+package com.apgsga.microservice.patch.core.impl.jenkins;
+
+
+import com.google.common.collect.Sets;
+
+import java.util.Set;
+
+public class InstallDbObjectsInfos {
+
+    public String dbPatchTag;
+    public String dbPatchBranch;
+    public Set<String> dbObjectsModuleNames = Sets.newHashSet();
+
+    public InstallDbObjectsInfos(String dbPatchTag, String dbPatchBranch) {
+        this.dbPatchTag = dbPatchTag;
+        this.dbPatchBranch = dbPatchBranch;
+    }
+}

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/InstallPipelineParameter.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/InstallPipelineParameter.java
@@ -8,7 +8,7 @@ import lombok.Value;
 
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 @JsonDeserialize(builder = InstallPipelineParameter.InstallPipelineParameterBuilder.class)
 @Builder
@@ -22,6 +22,8 @@ public class InstallPipelineParameter {
     List<PackagerInfo> packagers;
     Boolean installDbPatch;
     String dbZipInstallFrom;
+    Boolean isProductionInstallation;
+    Map<String,InstallDbObjectsInfos> installDbObjectsInfos; // Key is a patchNumber
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class InstallPipelineParameterBuilder {}

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClientImpl.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClientImpl.java
@@ -105,6 +105,8 @@ public class JenkinsClientImpl implements JenkinsClient {
 				.packagers(preprocessor.retrievePackagerInfoFor(parameters.getPatchNumbers(),parameters.getTarget()))
 				.installDbPatch(preprocessor.needInstallDbPatchFor(parameters.getPatchNumbers()))
 				.dbZipInstallFrom(preprocessor.retrieveDbDeployInstallerHost(parameters.getTarget()))
+				.isProductionInstallation(preprocessor.retrieveTargetForStageName(parameters.getTarget()).equalsIgnoreCase("production"))
+				.installDbObjectsInfos(preprocessor.retrieveDbObjectInfoFor(parameters.getPatchNumbers()))
 				.build();
 		startGenericPipelineJobBuilder("install",
 				jenkinsPipelineInstallScript,

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClientImpl.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsClientImpl.java
@@ -105,7 +105,7 @@ public class JenkinsClientImpl implements JenkinsClient {
 				.packagers(preprocessor.retrievePackagerInfoFor(parameters.getPatchNumbers(),parameters.getTarget()))
 				.installDbPatch(preprocessor.needInstallDbPatchFor(parameters.getPatchNumbers()))
 				.dbZipInstallFrom(preprocessor.retrieveDbDeployInstallerHost(parameters.getTarget()))
-				.isProductionInstallation(preprocessor.retrieveTargetForStageName(parameters.getTarget()).equalsIgnoreCase("production"))
+				.isProductionInstallation(preprocessor.retrieveTargetForStageName("produktion").equalsIgnoreCase(parameters.getTarget()))
 				.installDbObjectsInfos(preprocessor.retrieveDbObjectInfoFor(parameters.getPatchNumbers()))
 				.build();
 		startGenericPipelineJobBuilder("install",

--- a/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsPipelinePreprocessor.java
+++ b/apg-patch-service-core/src/main/java/com/apgsga/microservice/patch/core/impl/jenkins/JenkinsPipelinePreprocessor.java
@@ -4,6 +4,7 @@ import com.apgsga.microservice.patch.api.Package;
 import com.apgsga.microservice.patch.api.*;
 import com.apgsga.microservice.patch.exceptions.Asserts;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +13,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -105,6 +107,20 @@ public class JenkinsPipelinePreprocessor {
             });
         });
         return packagers;
+    }
+
+    public Map<String,InstallDbObjectsInfos> retrieveDbObjectInfoFor(Set<String> patchNumbers) {
+        LOGGER.info("Retrieving dbObject info for following patch(es) : " + patchNumbers.toString());
+        Map<String,InstallDbObjectsInfos> installDbObjectsInfos = Maps.newHashMap();
+        patchNumbers.forEach(number -> {
+            Patch patch = retrievePatch(number);
+            InstallDbObjectsInfos dboInfo = new InstallDbObjectsInfos(patch.getDbPatch().getPatchTag(),patch.getDbPatch().getDbPatchBranch());
+            patch.getDbPatch().getDbObjects().forEach(dbo -> {
+                dboInfo.dbObjectsModuleNames.add(dbo.getModuleName());
+            });
+            installDbObjectsInfos.put(number,dboInfo);
+        });
+        return installDbObjectsInfos;
     }
 
     public String retrieveDbDeployInstallerHost(String target) {


### PR DESCRIPTION
We need additional information to be passed to the install pipeline in order to merge the DB-Objects back on the prod branch for patches which have be install to production.